### PR TITLE
Idea for easing migration to std::*_ptr types

### DIFF
--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -101,6 +101,8 @@ For each pointer type there a non-const and a const `typedef`:
 * `UniquePtr` and `ConstUniquePtr`
 * `WeakPtr` and `ConstWeakPtr`
 
+For partial backwards compatibility with ROS 1, these `typedefs` will also be added to ROS 1 packages using `boost::*_ptr` types. Migrating ROS 1 code to use the `typedefs` will ease migration to ROS 2.
+
 
 ## Services
 


### PR DESCRIPTION
It won't provide complete backwards compatibility, unless we also typedef the pointer casting functions (`std::dynamic_pointer_cast` vs `boost::dynamic_pointer_cast` and so forth for weak and unique pointers as well). But it's a step towards easing the migration.
