### PR TITLE
rename raw pointers and keep deprecated ROS 1 typedefs

### DIFF
--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -96,10 +96,13 @@ The comparison operators `==` and `!=` perform the comparison on a per member ba
 The struct contains `typedefs` for the four common pointer types `plain pointer`, `std::shared_ptr`, `std::unique_ptr`, `std::weak_ptr`.
 For each pointer type there a non-const and a const `typedef`:
 
-* `Ptr` and `ConstPtr`
+* `RawPtr` and `ConstRawPtr`
 * `SharedPtr` and `ConstSharedPtr`
 * `UniquePtr` and `ConstUniquePtr`
 * `WeakPtr` and `ConstWeakPtr`
+
+For similarity to ROS 1 the `typedefs` `Ptr` and `ConstPtr` still exist but are deprecated.
+In contrast to ROS 1 they use `std::shared_ptr` instead of Boost.
 
 
 ## Services


### PR DESCRIPTION
The renames `Ptr` to `RawPtr` to not break expectations.

It keeps `Ptr` as a `std::shared_ptr` (as it is in ROS 1) but deprecates its usage.
