### PR TITLE
mdast-lint based markdown checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: ruby
 rvm:
 - 2.1
-install: gem install jekyll
-script: jekyll build
+
+install:
+- gem install jekyll
+- cd scripts/nodejs; npm install
+
+script: 
+- jekyll build
+- cd scripts/nodejs; ./node_modules/.bin/mdast ../../articles --frail --no-color -q --config-path ./mdast/mdastrc
 
 # branch whitelist
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "jekyll"
+gem "pygments.rb"
 # gem "html-proofer"

--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,5 @@ exclude:
  - LICENSE
  - README.md
  - vendor
+ - scripts
+ 

--- a/scripts/nodejs/.gitignore
+++ b/scripts/nodejs/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/nodejs/mdast/README.md
+++ b/scripts/nodejs/mdast/README.md
@@ -1,0 +1,26 @@
+# Markdown checks
+
+`npm` is a nodejs-based package manager for javascript modules. `npm` reads a package.json file and installs modules as defined there.
+It can install files to system, to user home, or to a local folder ('`node_modules`'). Softlonks to executable scripts are installed to `node_modules/.bin`.
+
+`npm` can conveniently be installed via `nvm` (https://github.com/creationix/nvm), or apt-get.
+
+The `package.json` file defines the requirements to be installed via `npm`.
+
+`mdast` (https://github.com/wooorm/mdast) is a javascript based markdown parser / emitter, with additional plugins providing e.g. linting. `mdast` itself can be used to fix style issues, but it may produce bad results when the input is invalid (so manual checks are advised).
+The file `.mdastrc` configures the plugins to be used.
+
+
+Commands:
+
+# Provide a nodejs version in the current env
+nvm use 4.0.0
+
+# in the folder with package.json, installs packages with dependencies to local folder
+npm install
+
+# check all md files in folder recursively using given config file and options
+./node_modules/.bin/mdast ../../articles --frail --no-color -q --config-path ./mdast/mdastrc
+
+# when providing single file, mdast produces 'fixed' markdown
+./node_modules/.bin/mdast ../../articles/somefile.md

--- a/scripts/nodejs/mdast/mdastrc
+++ b/scripts/nodejs/mdast/mdastrc
@@ -3,7 +3,7 @@
     "lint": {
         "unordered-list-marker-style": "consistent",
         "list-item-bullet-indent": true,
-        "list-item-indent": true,
+        "list-item-indent": "space",
         "list-item-spacing": true,
         "no-html": false,
         "maximum-line-length": true,

--- a/scripts/nodejs/mdast/mdastrc
+++ b/scripts/nodejs/mdast/mdastrc
@@ -1,0 +1,35 @@
+{
+"plugins": {
+    "lint": {
+        "unordered-list-marker-style": "consistent",
+        "list-item-bullet-indent": true,
+        "list-item-indent": true,
+        "list-item-spacing": true,
+        "no-html": false,
+        "maximum-line-length": true,
+        "no-file-name-mixed-case": true,
+        "heading-increment": true,
+        "no-multiple-toplevel-headings": true,
+        "no-consecutive-blank-lines": true,
+        "no-file-name-irregular-characters": true,
+        "maximum-line-length": 9000,
+        "maximum-heading-length": 300,
+        "table-pipes": true,
+        "table-pipe-alignment": true,
+        "no-heading-punctuation": true,
+        "no-duplicate-headings": true,
+        "emphasis-marker": "*",
+        "no-tabs": true,
+        "blockquote-indentation": true,
+        "strong-marker": "*",
+        "external": ["mdast-lint-sentence-newline"]
+    }
+  },
+  "settings": {
+    "bullet": "*",
+    "listItemIndent": "1",
+    "strong": "*",
+    "emphasis": "*"
+  }
+
+}

--- a/scripts/nodejs/package.json
+++ b/scripts/nodejs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "markdowncheck",
+  "version": "0.0.0",
+  "description": "markdown checks using mdast",
+  "private": true,
+  "comment": "untildify dependency of npm-prefix@1.1.0 has bug",
+  "dependencies": {
+    "mdast": "^2.1.0",
+    "mdast-lint": "^1.1.1",
+    "mdast-lint-sentence-newline": "^0.1.0",
+    "npm-prefix": "1.0.1"
+  }
+}


### PR DESCRIPTION
As suggested in #34, this PR introduces checking of the markdown files in `articles/`, failing the travis build when style errors are found.

Example output: https://travis-ci.org/tkruse/design/builds/88631913

The inner README.md file provides some info and instructions to run locally. The commands could be wrapped in shell or Makefile scripting, but I did not add that since I don't know your preferences.

Notes:
- I would have preferred a python solution, you probably too, but this is the best I could find at the time.
- I put the additional files into subfolders to allow easy copy&paste into other projects, putting everything into the project root would also work.
- The mdast-lint configuration of the style rules are copied from another project I work on, so they probably need tweaking to your preferences. Note that for several current style items, the easiest solution is to run mdast to fix the files as explained in the README.md, by piping mdast output into the source file.
- I had to add `pygments.rb` in `Gemfile` to get things to run on travis.
- If you like this, consider mentioning this tool on the ROS2 style guide wiki page.
