### PR TITLE
enable pygment highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ oauth_client_id: efa6dd8eae9106381720
 
 markdown: kramdown
 highlighter: pygments
+pygments: true
 
 relative_permalinks: false
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
 
     <link href="{{ site.baseurl }}/css/bootstrap.css" rel="stylesheet">
     <link href="{{ site.baseurl }}/css/ros2-design.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/css/pygments.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/articles/120_realtime_background.md
+++ b/articles/120_realtime_background.md
@@ -95,15 +95,14 @@ Additionally, the heap allocates and frees memory blocks in such a way that lead
 
 #### Lock memory, prefault stack
 
-```cpp
+{% highlight cpp %}
 if (mlockall(MCL_CURRENT|MCL_FUTURE) == -1) {
   perror("mlockall failed");
   exit(-2);
 }
 unsigned char dummy[MAX_SAFE_STACK];
-
 memset(dummy, 0, MAX_SAFE_STACK);
-```
+{% endhighlight %}
 
 [`mlockall`](http://linux.die.net/man/2/mlockall) is a Linux system call for locking the process's virtual address space into RAM, preventing the memory that will be accessed by the process from getting paged into swap space.
 
@@ -113,7 +112,7 @@ The [`memset`](http://linux.die.net/man/3/memset) call pre-loads each block of m
 
 #### Allocate dynamic memory pool
 
-```cpp
+{% highlight cpp %}
 if (mlockall(MCL_CURRENT | MCL_FUTURE))
   perror("mlockall failed:");
 
@@ -130,7 +129,7 @@ for (i=0; i < SOMESIZE; i+=page_size) {
   buffer[i] = 0;
 }
 free(buffer);
-```
+{% endhighlight %}
 
 The intro to this section stated that dynamic memory allocation is usually not real-time safe.
 However, this code snippet shows how to make dynamic memory allocation real-time safe (mostly).

--- a/articles/200_migration_guide_from_ros1.md
+++ b/articles/200_migration_guide_from_ros1.md
@@ -159,7 +159,7 @@ This package is in a catkin workspace, located at `~/ros1_talker`.
 
 Here's the directory layout of our catkin workspace:
 
-~~~
+{% highlight bash %}
 $ cd ~/ros1_talker
 $ find .
 .
@@ -168,7 +168,7 @@ $ find .
 ./src/talker/package.xml
 ./src/talker/CMakeLists.txt
 ./src/talker/talker.cpp
-~~~
+{% endhighlight %}
 
 Here is the content of those three files:
 

--- a/css/pygments.css
+++ b/css/pygments.css
@@ -1,0 +1,61 @@
+.hll { background-color: #ffffcc }
+.c { color: #408080; font-style: italic } /* Comment */
+.err { border: 1px solid #FF0000 } /* Error */
+.k { color: #008000; font-weight: bold } /* Keyword */
+.o { color: #666666 } /* Operator */
+.cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.cp { color: #BC7A00 } /* Comment.Preproc */
+.c1 { color: #408080; font-style: italic } /* Comment.Single */
+.cs { color: #408080; font-style: italic } /* Comment.Special */
+.gd { color: #A00000 } /* Generic.Deleted */
+.ge { font-style: italic } /* Generic.Emph */
+.gr { color: #FF0000 } /* Generic.Error */
+.gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.gi { color: #00A000 } /* Generic.Inserted */
+.go { color: #888888 } /* Generic.Output */
+.gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.gs { font-weight: bold } /* Generic.Strong */
+.gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.gt { color: #0044DD } /* Generic.Traceback */
+.kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.kp { color: #008000 } /* Keyword.Pseudo */
+.kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.kt { color: #B00040 } /* Keyword.Type */
+.m { color: #666666 } /* Literal.Number */
+.s { color: #BA2121 } /* Literal.String */
+.na { color: #7D9029 } /* Name.Attribute */
+.nb { color: #008000 } /* Name.Builtin */
+.nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.no { color: #880000 } /* Name.Constant */
+.nd { color: #AA22FF } /* Name.Decorator */
+.ni { color: #999999; font-weight: bold } /* Name.Entity */
+.ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.nf { color: #0000FF } /* Name.Function */
+.nl { color: #A0A000 } /* Name.Label */
+.nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.nt { color: #008000; font-weight: bold } /* Name.Tag */
+.nv { color: #19177C } /* Name.Variable */
+.ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.w { color: #bbbbbb } /* Text.Whitespace */
+.mf { color: #666666 } /* Literal.Number.Float */
+.mh { color: #666666 } /* Literal.Number.Hex */
+.mi { color: #666666 } /* Literal.Number.Integer */
+.mo { color: #666666 } /* Literal.Number.Oct */
+.sb { color: #BA2121 } /* Literal.String.Backtick */
+.sc { color: #BA2121 } /* Literal.String.Char */
+.sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.s2 { color: #BA2121 } /* Literal.String.Double */
+.se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.sh { color: #BA2121 } /* Literal.String.Heredoc */
+.si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.sx { color: #008000 } /* Literal.String.Other */
+.sr { color: #BB6688 } /* Literal.String.Regex */
+.s1 { color: #BA2121 } /* Literal.String.Single */
+.ss { color: #19177C } /* Literal.String.Symbol */
+.bp { color: #008000 } /* Name.Builtin.Pseudo */
+.vc { color: #19177C } /* Name.Variable.Class */
+.vg { color: #19177C } /* Name.Variable.Global */
+.vi { color: #19177C } /* Name.Variable.Instance */
+.il { color: #666666 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
This PR enables pygments, adds a Pygmentize-generated stylesheet, and changes a few code blocks to use native Jekyll native syntax-highlighting. I don't know if this is the best way to do it, but this seems to work and fixes #77 (at least running locally on my box).
