### PR TITLE
remove usage of baseurl

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,9 +10,9 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
-    <script src="{{ site.baseurl }}/js/bootstrap.min.js"></script>
-    <script src="{{ site.baseurl }}/js/github.js"></script>
-    <script src="{{ site.baseurl }}/js/ros2-design.js"></script>
+    <script src="/js/bootstrap.min.js"></script>
+    <script src="/js/github.js"></script>
+    <script src="/js/ros2-design.js"></script>
     <!-- Google Analytics -->
     <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,10 +8,10 @@
 
     <title>{% if page.html_title %}{{ page.html_title }}{% else %}{{ page.title }}{% endif %}</title>
 
-    <link rel="icon" type="image/png" href="{{ site.baseurl }}/favicon.png" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
 
-    <link href="{{ site.baseurl }}/css/bootstrap.css" rel="stylesheet">
-    <link href="{{ site.baseurl }}/css/ros2-design.css" rel="stylesheet">
+    <link href="/css/bootstrap.css" rel="stylesheet">
+    <link href="/css/ros2-design.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -33,12 +33,12 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{ site.baseurl }}/">{{ site.name }}</a>
+          <a class="navbar-brand" href="/">{{ site.name }}</a>
         </div>
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">{% for p in site.pages %}{% if p.show_in_nav %}
             <li>
-              <a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a>
+              <a href="{{ p.url }}">{{ p.title }}</a>
             </li>{% endif %}{% endfor %}
           </ul>
           <ul class="nav navbar-nav navbar-right">

--- a/_layouts/login.html
+++ b/_layouts/login.html
@@ -5,7 +5,7 @@
     {{ content }}
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
 
-    <script src="{{ site.baseurl }}/js/login.js"></script>
+    <script src="/js/login.js"></script>
   </div>
   <div class="sidebar-container col-md-3">
     {% include sidebar.html %}

--- a/articles/serialization.md
+++ b/articles/serialization.md
@@ -115,14 +115,14 @@ The message used by the userland code stores its data directly.
 For each communication channel the message data is then copied into the serialization specific message representation.
 The serialization library will perform the serialization into the wire format from there.
 
-<img src="{{ site.baseurl }}/img/serialization_pipeline_a.png"/>
+<img src="/img/serialization_pipeline_a.png"/>
 
 #### Pipeline B
 
 The message fields can be serialized directly into the wire format using custom code.
 While this avoids the extra data copy it requires a significant effort for implementing the custom serialization routine.
 
-<img src="{{ site.baseurl }}/img/serialization_pipeline_b.png"/>
+<img src="/img/serialization_pipeline_b.png"/>
 
 #### Pipeline C
 
@@ -131,7 +131,7 @@ Since the data is stored directly in the serialization library specific represen
 
 This assumes that the API of the serialization library specific representation can be wrapped inside the ROS message API (see [Technical Issues -> Variances in field types](#variances_in_field_types)).
 
-<img src="{{ site.baseurl }}/img/serialization_pipeline_c.png"/>
+<img src="/img/serialization_pipeline_c.png"/>
 
 ### Select message storage
 

--- a/contribute.md
+++ b/contribute.md
@@ -7,7 +7,7 @@ show_in_nav: true
 # Contribute
 
 There are many ways you can contribute to the ROS 2.0 design effort.
-The most important of which is probably to review the list of articles posted on the [home page]({{ site.baseurl }}/) and familiarize yourself with the discussions surrounding an issue before getting involved.
+The most important of which is probably to review the list of articles posted on the [home page](/) and familiarize yourself with the discussions surrounding an issue before getting involved.
 This will help keep everyone on the same page and prevent having to discuss things multiple times.
 
 ## The Side Bar
@@ -76,7 +76,7 @@ First check to see if you already have a fork of this repository:
 
 If you do not, then browse to this [repository](https://github.com/ros2/design) site and click on the "Fork" button:
 
-<img style="height: 50px;" src="{{ site.baseurl }}/img/fork.png"/>
+<img style="height: 50px;" src="/img/fork.png"/>
 
 Github will now go off and create a fork off this repository into your Github account.
 Then you can clone your fork of the repository by running this command:

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ html_title: Design
 This site is repository of articles which are designed to inform and guide the ROS 2.0 design efforts.
 The goal of the ROS 2.0 project is to leverage what is great about ROS 1.x and improve what isn't.
 
-If you would like to contribute, checkout the [contribute]({{ site.baseurl }}/contribute.html) page to learn how.
+If you would like to contribute, checkout the [contribute](/contribute.html) page to learn how.
 
 The best mailing list for discussing these topics is [ros-sig-ng-ros@googlegroups.com](mailto:ros-sig-ng-ros@googlegroups.com).
  You can view the archives [here](https://groups.google.com/forum/?fromgroups#!forum/ros-sig-ng-ros)
@@ -23,7 +23,7 @@ Here is a list of the articles (white papers) which have been written so far. Th
     {% if p.url contains 'articles/' and p.published == true %}
 ----
 
-#### [{{ p.title }}]({{ site.baseurl }}{{ p.url }})
+#### [{{ p.title }}]({{ p.url }})
 
 > {{ p.abstract }}
     {% endif %}
@@ -41,7 +41,7 @@ These articles are not finished or maybe not even started yet:
     {% if p.url contains 'articles/' and p.published != true %}
 ----
 
-#### [{{ p.title }}]({{ site.baseurl }}{{ p.url }})
+#### [{{ p.title }}]({{ p.url }})
 
 > {{ p.abstract }}
     {% endif %}


### PR DESCRIPTION
With #81 setting the `baseurl` to be empty there is no use in keeping these.
