### PR TITLE
add rules for array default values

### DIFF
--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -111,9 +111,11 @@ A field of type `array` can optionally specify a default value.
 - default values for an array must start with an opening square bracket (`[`) and end with a closing square bracket (`]`)
 - each value within the array must be separated with a comma (`,`)
 
-Additional rule for string arrays:
+Additional rule for `string` arrays:
+- string arrays must contain only `string`s respecting the following rules:
+  - a string value which can optionally be quoted with either single quotes (`'`) or double quotes (`"`)
 
-- every element of a string array must be quoted using either single quote (`'`) or double quote (`"`)
+  - a double-quoted (`"`) string (respectively single-quoted (`'`)) should have any inner double quotes (respectively single quotes) escaped
 
 <div class="alert alert-warning" markdown="1">
   <b>TODO:</b> default values are currently not supported for <i>complex</i> fields

--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -103,6 +103,8 @@ If no default value is specified a common default value is used:
 - for `bool` it is `false`
 - for *numeric* types it is a `0` value
 - for `string` it is an *empty* string
+- for *static size arrays* it is an array of N elements with its fields zero-initialized
+- for *bounded size arrays* and *dynamic size arrays* it is an empty array `[]`
 
 #### Array default values
 
@@ -110,11 +112,13 @@ A field of type `array` can optionally specify a default value.
 
 - default values for an array must start with an opening square bracket (`[`) and end with a closing square bracket (`]`)
 - each value within the array must be separated with a comma (`,`)
+- all values in the array must be of the same type as the field
+- there cannot be a comma `,` before the first value of the array
+- a trailing comma after the last element of the array is ignored
 
 Additional rule for `string` arrays:
 - string arrays must contain only `string`s respecting the following rules:
   - a string value which can optionally be quoted with either single quotes (`'`) or double quotes (`"`)
-
   - a double-quoted (`"`) string (respectively single-quoted (`'`)) should have any inner double quotes (respectively single quotes) escaped
 
 <div class="alert alert-warning" markdown="1">

--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -104,8 +104,19 @@ If no default value is specified a common default value is used:
 - for *numeric* types it is a `0` value
 - for `string` it is an *empty* string
 
+#### Array default values
+
+A field of type `array` can optionally specify a default value.
+
+- default values for an array must start with an opening square bracket (`[`) and end with a closing square bracket (`]`)
+- each value within the array must be separated with a comma (`,`)
+
+Additional rule for string arrays:
+
+- every element of a string array must be quoted using either single quote (`'`) or double quote (`"`)
+
 <div class="alert alert-warning" markdown="1">
-  <b>TODO:</b> default values are currently not supported for <code>string array</code> fields and <i>complex</i> fields
+  <b>TODO:</b> default values are currently not supported for <i>complex</i> fields
 </div>
 
 ### Constants


### PR DESCRIPTION
this adds rules defining default values for arrays in IDL.
It also specifies that string arrays elements must be quoted

related to https://github.com/ros2/rosidl/issues/206