### PR TITLE
Add article about WideStrings.

### DIFF
--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -2,7 +2,8 @@
 layout: default
 title: Unicode Support
 abstract:
-  This article desribes how ROS 2 will support multi-byte character sets.
+  This article describes how ROS 2 will support sending multi-byte character data using the [Unicode](https://en.wikipedia.org/wiki/Unicode) standard.
+  It also describes how such data will be sent over the ROS 1 bridge.
 author: '[Chris Lalancette](https://github.com/clalancette)'
 published: true
 ---
@@ -22,8 +23,6 @@ Original Author: {{ page.author }}
 
 Some users would like to send text data in languages that cannot be represented by ascii characters.
 Currently ROS 1 only supports ASCII data in the string field but [allows users to populate it with UTF-8](http://wiki.ros.org/msg).
-This article describes how ROS 2 will support sending multi-byte character data using the [Unicode](https://en.wikipedia.org/wiki/Unicode) standard.
-It also describes how such data will be sent over the ROS 1 bridge.
 
 Note that topic names cannot use multi-byte characters as they are disallowed by the DDS specification.
 See the [topic and service name](/articles/topic_and_service_names.html) design document for more information.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Unicode Support
+permalink: articles/wide_strings.html
 abstract:
   This article describes how ROS 2 will support sending multi-byte character data using the [Unicode](https://en.wikipedia.org/wiki/Unicode) standard.
   It also describes how such data will be sent over the ROS 1 bridge.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -149,7 +149,7 @@ Instead ROS 2 will use `char16_t` for characters of wide strings, and `std::u16s
 
 ```
 #include <codecvt>
-#include <iostream>
+#include <cstdio>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
@@ -176,7 +176,7 @@ int main(int argc, char * argv[])
   while (rclcpp::ok()) {
     std::u16string hello(u"Hello World: " + convert_to_u16.from_bytes(std::to_string(i++)));
     msg->data = hello;
-    std::cout << "Publishing: '" << msg->data.cpp_str() << "'" << std::endl;
+    std::printf("Publishing: '%s'\n", msg->data.cpp_str().c_str());
     chatter_pub->publish(msg);
     rclcpp::spin_some(node);
     loop_rate.sleep();

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -126,8 +126,8 @@ It should be computationally inexpensive for it to stop processing a string when
 
 ### Python 3
 
-In Python 3 a string is a sequence of characters where each character can take 1 or more bytes.
-Thus the ROS 2 API for dealing with `wstring` will take a string type in internally and convert it to UTF-16.
+In Python the `str` type will be used for both strings and wide strings.
+Bytes of a known encoding should be converted to a `str` using [bytes.decode](https://docs.python.org/3/library/stdtypes.html#bytes.decode) before being assigned to a field.
 
 **Example**
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -2,7 +2,8 @@
 layout: default
 title: WideStrings
 abstract:
-  Some ROS2 users would like to use multi-byte characters for topic data, suitable for supporting multi-byte languages.  This article lays out the problem, and explores potential solutions to this problem.
+  Some ROS2 users would like to use multi-byte characters for topic data, suitable for supporting multi-byte languages.
+  This article lays out the problem, and explores potential solutions to this problem.
 author: '[Chris Lalancette](https://github.com/clalancette)'
 published: true
 ---
@@ -20,31 +21,25 @@ Original Author: {{ page.author }}
 
 ## Background
 
-ROS2 currently supports the concept of strings, which are sequences of single-byte
-characters.  When working with ROS 2.0 topic data, some users would like to use multi-byte
-characters (e.g. UTF-8) for their topic data.  This article explores the
-problem and the possible solutions.  Note that this article specifically does
-not talk about binary data, as that is already handled by using uint8_t arrays.
-It also does not talk about using multi-byte characters for the topic *names*,
-as this is disallowed by the DDS specification.
+ROS2 currently supports the concept of strings, which are sequences of single-byte characters.
+When working with ROS 2.0 topic data, some users would like to use multi-byte characters (e.g. UTF-8) for their topic data.
+This article explores the problem and the possible solutions.
+Note that this article specifically does not talk about binary data, as that is already handled by using uint8_t arrays.
+It also does not talk about using multi-byte characters for the topic *names*, as this is disallowed by the DDS specification.
 
 ## Multi-byte character background
 
-Before delving into ROS 2.0 specifics, some time should be spent discussing multi-byte
-characters in general.  What is meant by multi-byte characters?  The original ASCII
-character set only provided for printable characters using binary sequences 0 to 127.
-Several extensions were made to this to use 128-255, but that approach only extended the
-character set to be able to cover a few more languages.  Several other encodings were
-created as the need arose, and it became clear by the 1990's that a worldwide standard
-was required.  Thus, Unicode was created to be a single specification that could cover
-all of the languages of the world.  The early versions of Unicode actually failed to
-live up to this expectation, and some of those early versions of Unicode are still
-baked into widely used software (Microsoft Windows, Java, etc).  Later on, the Unicode
-standard evolved to truly be able to cover the languages of the entire world, and this
-is what should generally be used for new designs.  As a side benefit, the newer versions of
-Unicode (UTF-8) are backwards compatible with ASCII.  There is a lot of history here, and
-things are much more complicated then the brief introduction above.  For more information,
-the following links provide introductory material:
+Before delving into ROS 2.0 specifics, some time should be spent discussing multi-byte characters in general.
+What is meant by multi-byte characters?
+The original ASCII character set only provided for printable characters using binary sequences 0 to 127.
+Several extensions were made to this to use 128-255, but that approach only extended the character set to be able to cover a few more languages.
+Several other encodings were created as the need arose, and it became clear by the 1990's that a worldwide standard was required.
+Thus, Unicode was created to be a single specification that could cover all of the languages of the world.
+The early versions of Unicode actually failed to live up to this expectation, and some of those early versions of Unicode are still baked into widely used software (Microsoft Windows, Java, etc).
+Later on, the Unicode standard evolved to truly be able to cover the languages of the entire world, and this is what should generally be used for new designs.
+As a side benefit, the newer versions of Unicode (UTF-8) are backwards compatible with ASCII.
+There is a lot of history here, and things are much more complicated then the brief introduction above.
+For more information, the following links provide introductory material:
 
 * [http://kunststube.net/encoding/](http://kunststube.net/encoding/)
 * [http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms](http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms)
@@ -54,8 +49,8 @@ the following links provide introductory material:
 The rest of this document is generally going to assume Unicode, unless stated otherwise.
 
 ## Introducing Wide Strings
-To support multi-byte characters, ROS 2.0 will introduce the concept of a wide string.  There are a
-few basic questions to answer on how a wide string will be integrated into ROS 2.0:
+To support multi-byte characters, ROS 2.0 will introduce the concept of a wide string.
+There are a few basic questions to answer on how a wide string will be integrated into ROS 2.0:
 
 * What is the size impact of the wide string?
 * What is the encoding of the wide string?
@@ -65,44 +60,34 @@ Each of these questions will be examined in more detail below.
 
 ### What is the size impact of the wide string?
 
-There are 2 parts to this question.  One is how the wide string is mapped onto the underlying
-DDS implementation, which defines how large messages will be on-the-wire (and on disk).  The
-other part of the question deals with the runtime impact (in terms of speed and code size) of
-having to deal with wide strings.
+There are 2 parts to this question.
+One is how the wide string is mapped onto the underlying DDS implementation, which defines how large messages will be on-the-wire (and on disk).
+The other part of the question deals with the runtime impact (in terms of speed and code size) of having to deal with wide strings.
 
 **Mapping onto the DDS implementation**
 
-There are a couple of different ways that a wide string could be mapped onto a
-DDS implementation.  The first way it could be mapped is onto a uint8_t byte
-array.  While this would work, it has the downside that the byte array would be
-"opaque", and any introspection tools into DDS wouldn't see anything but a stream
-of bytes.  The second way it could be mapped is onto the "wchar/wstring" type
-defined by the DDS specification.  The DDS specification itself doesn't define
-a size for wchar, but the X-Types specification (for DDS introspection) does
-say that a wchar should be mapped onto a Char32.  Thus, all known encodings
-would fit into a wchar, and DDS introspection tools could look into wstrings.
+There are a couple of different ways that a wide string could be mapped onto a DDS implementation.
+The first way it could be mapped is onto a uint8_t byte array.
+While this would work, it has the downside that the byte array would be "opaque", and any introspection tools into DDS wouldn't see anything but a stream of bytes.
+The second way it could be mapped is onto the "wchar/wstring" type defined by the DDS specification.
+The DDS specification itself doesn't define a size for wchar, but the X-Types specification (for DDS introspection) does say that a wchar should be mapped onto a Char32.
+Thus, all known encodings would fit into a wchar, and DDS introspection tools could look into wstrings.
 Thus, the current design of wide strings map onto wchar DDS types.
 
 **Runtime impact of wide string**
 
-Dealing with wide strings puts more strain on the software of a system, both in
-terms of speed and in terms of code size.  This is felt most acutely when talking
-about small microcontrollers, where both flash size (code space) and performance
-(processor speed) are at a premium.  Some of the common encodings (including UTF-8)
-are defined as being variable width, meaning that a character can take 1, 2, or 4
-characters to represent.  These encoding also typically have the ability to combine
-one character with the next in non-trivial ways.  As one of the goals of ROS 2.0
-is to support small, constrained systems, dealing with wide strings may be out of
-the question.  Thus, the current ROS 2.0 design for wide strings makes them optional,
-defines them as a separate type from regular strings, and recommends against
-using them for common messages.
+Dealing with wide strings puts more strain on the software of a system, both in terms of speed and in terms of code size.
+This is felt most acutely when talking about small microcontrollers, where both flash size (code space) and performance (processor speed) are at a premium.
+Some of the common encodings (including UTF-8) are defined as being variable width, meaning that a character can take 1, 2, or 4 characters to represent.
+These encoding also typically have the ability to combine one character with the next in non-trivial ways.
+As one of the goals of ROS 2.0 is to support small, constrained systems, dealing with wide strings may be out of the question.
+Thus, the current ROS 2.0 design for wide strings makes them optional, defines them as a separate type from regular strings, and recommends against using them for common messages.
 
 ### What is the encoding of the wide string?
 
-There are two main ways that ROS 2.0 can provide for the encoding of a wide string.  Either
-ROS 2.0 can define exactly what the encoding will be for all strings, or it can allow the
-user to specify the encoding when handing it to ROS 2.0.  There are pros and cons to each
-approach.
+There are two main ways that ROS 2.0 can provide for the encoding of a wide string.
+Either ROS 2.0 can define exactly what the encoding will be for all strings, or it can allow the user to specify the encoding when handing it to ROS 2.0.
+There are pros and cons to each approach.
 
 **ROS 2.0 defines the encoding**
 
@@ -112,9 +97,8 @@ Pros:
 
 Cons:
 
-* If the user-level code uses a different encoding, the user is responsible
-for doing a conversion to the ROS 2.0 defined encoding.  This can involve
-some runtime cost.
+* If the user-level code uses a different encoding, the user is responsible for doing a conversion to the ROS 2.0 defined encoding.
+  This can involve some runtime cost.
 
 **User defines the encoding**
 
@@ -126,28 +110,25 @@ Cons:
 
 * The user must always tell ROS 2.0 what encoding the data is in.
 * The encoding needs to be transmitted on the wire to the other side.
-* It is not clear how ROS 2.0 will transmit the encoding.  Fixed list?  Which
-encodings go into the list?
+* It is not clear how ROS 2.0 will transmit the encoding.
+  Fixed list?
+  Which encodings go into the list?
 
-While a user defined encoding looks somewhat attractive at first, the downsides
-to it make it difficult to determine exactly which encodings are in use.  The
-downsides also mean that any program that wants to parse ROS 2 messages (or bag
-files) may potentially have to deal with many different encodings.  Additionally,
-Unicode (and in particular, UTF-8) are very commonplace now, while other encodings
-are becoming more esoteric.  Even earlier Unicode (UTF-16 and UTF-32) encodings are
-essentially deprecated in favor of UTF-8.  For these reasons, the current design of
-the ROS 2.0 wide string is to use a UTF-8 encoding for all strings.
+While a user defined encoding looks somewhat attractive at first, the downsides to it make it difficult to determine exactly which encodings are in use.
+The downsides also mean that any program that wants to parse ROS 2 messages (or bag files) may potentially have to deal with many different encodings.
+Additionally, Unicode (and in particular, UTF-8) are very commonplace now, while other encodings are becoming more esoteric.
+Even earlier Unicode (UTF-16 and UTF-32) encodings are essentially deprecated in favor of UTF-8.
+For these reasons, the current design of the ROS 2.0 wide string is to use a UTF-8 encoding for all strings.
 
 ### What does the API look like to a user of ROS 2.0?
 
 #### Python 3
 
-Python 3 splits byte arrays from strings pretty cleanly.  Thus, in Python 3, a
-string is a sequence of characters, where each character can take 1 or more bytes.
-Byte arrays are sequences of bytes.  Thus, the ROS 2.0 API for dealing with wide strings
-(such as the publish API) will take just a string type in, and encode it as utf-8.
-The ROS 2.0 API for dealing with regular strings will take a string type in, and
-encode it as ASCII.
+Python 3 splits byte arrays from strings pretty cleanly.
+Thus, in Python 3, a string is a sequence of characters, where each character can take 1 or more bytes.
+Byte arrays are sequences of bytes.
+Thus, the ROS 2.0 API for dealing with wide strings (such as the publish API) will take just a string type in, and encode it as utf-8.
+The ROS 2.0 API for dealing with regular strings will take a string type in, and encode it as ASCII.
 
 **Example**
 
@@ -187,15 +168,15 @@ if __name__ == '__main__':
     main()
 ```
 
-Notice that this code looks almost identical to the same demo for String.  That's because
-in python, the characters in the string and the byte representation are cleanly
-separated.  Thus, the API looks exactly the same as it would for the String type.
+Notice that this code looks almost identical to the same demo for String.
+That's because in python, the characters in the string and the byte representation are cleanly separated.
+Thus, the API looks exactly the same as it would for the String type.
 
 #### C++
 
-C++ doesn't have good built-in support for wide strings.  Using wchar_t is generally
-not a good option, as wchar_t has different sizes on different platforms (2 bytes on
-Windows, 4 bytes on Linux).  Thus, ROS 2.0 will define a new type to deal with wide strings.
+C++ doesn't have good built-in support for wide strings.
+Using wchar_t is generally not a good option, as wchar_t has different sizes on different platforms (2 bytes on Windows, 4 bytes on Linux).
+Thus, ROS 2.0 will define a new type to deal with wide strings.
 The APIs that deal with wide strings will expect this new type to be passed in.
 
 **Example**
@@ -237,25 +218,25 @@ int main(int argc, char * argv[])
 }
 ```
 
-Here, ROS 2 has implemented a new type called "utf8_string" (this is still to be implemented,
-and the name may change).  The publisher takes in types of utf8_string, and generates the
-correct data on the wire.
+Here, ROS 2 has implemented a new type called "utf8_string" (this is still to be implemented, and the name may change).
+The publisher takes in types of utf8_string, and generates the correct data on the wire.
 
 ### Bounded wide strings
 
-A note on bounded wide strings.  ROS 2.0 allows for "bounded" strings and wide strings.  These
-are strings that can be no longer than their bounded number.  In the case of strings, the
-width of a character == the width of a byte in most cases, so the number of bytes in a bounded
-string is generally the bound (plus 1 for the NULL-termination).  Wide strings are a little bit different.
-When dealing with bounded wide strings, the bound is on the number of characters, not bytes.  Thus
-the maximum number of bytes the bounded wide string can be may be, and most likely will be, larger
-than the number of characters.
+A note on bounded wide strings.
+ROS 2.0 allows for "bounded" strings and wide strings.
+These are strings that can be no longer than their bounded number.
+In the case of strings, the width of a character == the width of a byte in most cases, so the number of bytes in a bounded string is generally the bound (plus 1 for the NULL-termination).
+Wide strings are a little bit different.
+When dealing with bounded wide strings, the bound is on the number of characters, not bytes.
+Thus the maximum number of bytes the bounded wide string can be may be, and most likely will be, larger than the number of characters.
 
 ## Summary
 
 To summarize, the current ROS 2.0 design for wide strings:
 
-* Maps wide characters onto the DDS type wchar.  This in turn maps wide strings on the DDS type wstring.
+* Maps wide characters onto the DDS type wchar.
+  This in turn maps wide strings on the DDS type wstring.
 * Allows them to be optionally supported by an implementation.
 * Defines wide strings as a separate type from strings.
 * Recommends against using wide strings for common messages.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -104,8 +104,7 @@ Some wide string operations like splitting a string on a user perceived characte
 
 However, whole string equality checking is the same whether using wide strings or not.
 Further splitting a UTF-8 string on an ASCII character is identical to splitting an ASCII character on an ASCII string.
-If code on a microcontroller must do string manipluation then it could assert that a `string` only contains ASCII data.
-It should be computationally inexpensive for it to stop processing a string when it encounters a byte greater than 127.
+If code on a microcontroller must do string manipluation then it could assert that a `string` only contains ASCII data by ceasing to proces a string when it encounters a byte greater than 127.
 
 ## What does the API look like to a user of ROS 2?
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -122,27 +122,24 @@ Bytes of a known encoding should be converted to a `str` using [bytes.decode](ht
 **Example**
 
 ```python
-import sys
-from time import sleep
-
 import rclpy
-from rclpy.qos import qos_profile_default
-from std_msgs.msg import WString
+from test_msgs.msg import WStrings
 
 
 if __name__ == '__main__':
-    rclpy.init(sys.argv)
+    rclpy.init()
 
     node = rclpy.create_node('talker')
 
-    chatter_pub = node.create_publisher(WString, 'chatter', qos_profile_default)
+    chatter_pub = node.create_publisher(WStrings, 'chatter', 1)
 
-    msg = WString()
-    msg.data = 'Hello Wörld'
-    print('Publishing: "{0}"'.format(msg.data))
+    msg = WStrings()
+    msg.wstring_value = 'Hello Wörld'
+    print('Publishing: "{0}"'.format(msg.wstring_value))
     chatter_pub.publish(msg)
     node.destroy_node()
     rclpy.shutdown()
+
 ```
 
 ### C++

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -105,7 +105,7 @@ Their purpose is to restrinct the amount of memory used, so the bounds must be s
 If a `string` field is bounded then the size is given in bytes.
 Similarly the size of a bounded `wstring` is to be specified in words.
 It is the responsibility of whoever populates a bounded `string` or `wstring` to make sure it contains whole code points only.
-Partial code points are indistinuguishable from unknown encodings, so a bounded string whose last code point is incomplete will be published without error.
+Partial code points are indistinuguishable from invalid code points, so a bounded string whose last code point is incomplete is not guaranteed to be published.
 
 ## Runtime impact of wide string
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -38,30 +38,30 @@ The following links have more information about multi-byte characters and the hi
 
 
 ## Unicode Characters in Strings
+Two goals for ROS 2 strings are to be compatible with ROS 1 strings, and compatible with the DDS wire format.
 ROS 1 says string fields are to contain ASCII encoded data, but allows UTF-8.
 DDS-XTYPES mandates UTF-8 be used as the encoding of IDL type `string`.
-To be compatible with ROS 1 and DDS-XTYPES, in ROS 2 the content of a `string` is expected to be UTF-8.
+To be compatibile with both, in ROS 2 the content of a `string` is expected to be UTF-8.
 
-## Introducing Wide Strings
+## Wide Strings
 ROS 2 messages will have a new [primitive field type](/articles/interface_definition.html) `wstring`.
 This purpose is to allow ROS 2 nodes to comminicate with non-ROS DDS entities using an IDL containing a `wstring` field.
 The encoding of data in this type should be UTF-16 to match DDS-XTYPES 1.2.
 Since both UTF-8 and UTF-16 can encode the same code points, new ROS 2 messages should prefer `string` over `wstring`.
 
 ## Encodings are Required but not Guaranteed to be Enforced
-The choice of UTF-8 or UTF-16 for `string` and `wstring` are required, but it is up to the rmw implementation to enfoce them.
-They are not guaranteed to be enforced because it is unknown if it would be a significant performance hit on resource constrained systems.
-Further, users writing defensive code would already check that a string contains valid data after receiving it.
+`string` and `wstring` are required to be UTF-8 and UTF-16, but the requirement may not be enforced.
+Since ROS 2 is targeting resource constrained systems, it is left to the rmw implementation to choose whether or not to enforce the encoding.
+Further, since many users will write code to check check that a string contains valid data, checking the encoding may not be necessary in some cases.
 
 If a `string` or `wstring` field is populated with the wrong encoding then the behavior is undefined.
-It is possible the middleware may allow invalid data to be passed through to subscribers.
-Each subscriber is responsible for detecting and deciding how to handle it.
-For example, it could decode it using an encoding that has been agreed to out of band.
-Other subscribers like `ros2 topic echo` may echo the bytes in hexadecimal.
+It is possible the rmw implementation may allow invalid data to be passed through to subscribers.
+Each subscriber is responsible for detecting invalid data and deciding how to handle it.
+For example, subscribers like `ros2 topic echo` may echo the bytes in hexadecimal.
 
 The IDL specification forbids `string` from containing `NULL` values.
 For compatibility a ROS message `string` field must not contain zero bytes, and a `wstring` field must not contain zero words.
-This restriction is enforced.
+This restriction will be enforced.
 
 <div class="alert alert-warning" markdown="1">
   <b>TODO:</b> Can ROS 1 publish a string with NULL bytes?

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -51,7 +51,7 @@ Since both UTF-8 and UTF-16 can encode the same code points, new ROS 2 messages 
 ## Encodings are Required but not Guaranteed to be Enforced
 `string` and `wstring` are required to be UTF-8 and UTF-16, but the requirement may not be enforced.
 Since ROS 2 is targeting resource constrained systems, it is left to the rmw implementation to choose whether to enforce the encoding.
-Further, since many users will write code to check check that a string contains valid data, checking the encoding may not be necessary in some cases.
+Further, since many users will write code to check that a string contains valid data, checking again in lower layers may not be necessary in some cases.
 
 If a `string` or `wstring` field is populated with the wrong encoding then the behavior is undefined.
 It is possible the rmw implementation may allow invalid data to be passed through to subscribers.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -99,7 +99,7 @@ Partial code points are indistinuguishable from invalid code points, so a bounde
 Dealing with wide strings puts more strain on the software of a system, both in terms of speed and code size.
 UTF-8 and UTF-16 are both variable width encodings, meaning a code point can take 1 to 4 bytes depending on the encoding.
 It may take multiple code points to represent a single user perceived character.
-One of the goals of ROS 2 is to support microcontrollers that are contrained by both code size and processor speed.
+One of the goals of ROS 2 is to support microcontrollers that are constrained by both code size and processor speed.
 Some wide string operations like splitting a string on a user perceived character may not be possible on these devices.
 
 However, whole string equality checking is the same whether using wide strings or not.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -92,9 +92,11 @@ Both UTF-8 and UTF-16 are variable width encodings.
 To minimize the amount of memory used, the `string` and `wstring` types are to be stored in client libraries according to the smallest possible code point.
 This means `string` must be specified as a sequence of bytes, and `wstring` is to be specified as a sequence of words.
 
-Some DDS implementations use 32bit types to store wide strings values.
-This may be due to DDS-XTYPES 1.1 spec saying `wchar` is a 32bit value.
-ROS 2 will instead aim to be compatible with DDS-XTYPES 1.2 and use 16bit storage for wide characters.
+Some DDS implementations currently use 32bit types to store wide strings values.
+This may be due to DDS-XTYPES 1.1 section 7.3.1.5 specifying `wchar` as a 32bit value.
+However this changes in DDS-XTYPES 1.2 section 7.3.1.4 to be a 16bit value.
+It is expected that most DDS implementations will switch to 16bit character storage in the future.
+ROS 2 will aim to be compatible with DDS-XTYPES 1.2 and use 16bit storage for wide characters.
 Generated code for ROS 2 messages will automatically handle the conversion when a message is serialized or deserialized.
 
 ### Bounded wide strings

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -22,14 +22,14 @@ Original Author: {{ page.author }}
 ## Background
 
 ROS2 currently supports the concept of strings, which are sequences of single-byte characters.
-When working with ROS 2.0 topic data, some users would like to use multi-byte characters (e.g. UTF-8) for their topic data.
+When working with ROS 2 topic data, some users would like to use multi-byte characters (e.g. UTF-8) for their topic data.
 This article explores the problem and the possible solutions.
 Note that this article specifically does not talk about binary data, as that is already handled by using uint8_t arrays.
 It also does not talk about using multi-byte characters for the topic *names*, as this is disallowed by the DDS specification.
 
 ## Multi-byte character background
 
-Before delving into ROS 2.0 specifics, some time should be spent discussing multi-byte characters in general.
+Before delving into ROS 2 specifics, some time should be spent discussing multi-byte characters in general.
 What is meant by multi-byte characters?
 The original ASCII character set only provided for printable characters using binary sequences 0 to 127.
 Several extensions were made to this to use 128-255, but that approach only extended the character set to be able to cover a few more languages.
@@ -49,12 +49,12 @@ For more information, the following links provide introductory material:
 The rest of this document is generally going to assume Unicode, unless stated otherwise.
 
 ## Introducing Wide Strings
-To support multi-byte characters, ROS 2.0 will introduce the concept of a wide string.
-There are a few basic questions to answer on how a wide string will be integrated into ROS 2.0:
+To support multi-byte characters, ROS 2 will introduce the concept of a wide string.
+There are a few basic questions to answer on how a wide string will be integrated into ROS 2:
 
 * What is the size impact of the wide string?
 * What is the encoding of the wide string?
-* What does the API look like to a user of ROS 2.0?
+* What does the API look like to a user of ROS 2?
 
 Each of these questions will be examined in more detail below.
 
@@ -80,16 +80,16 @@ Dealing with wide strings puts more strain on the software of a system, both in 
 This is felt most acutely when talking about small microcontrollers, where both flash size (code space) and performance (processor speed) are at a premium.
 Some of the common encodings (including UTF-8) are defined as being variable width, meaning that a character can take 1, 2, or 4 characters to represent.
 These encoding also typically have the ability to combine one character with the next in non-trivial ways.
-As one of the goals of ROS 2.0 is to support small, constrained systems, dealing with wide strings may be out of the question.
-Thus, the current ROS 2.0 design for wide strings makes them optional, defines them as a separate type from regular strings, and recommends against using them for common messages.
+As one of the goals of ROS 2 is to support small, constrained systems, dealing with wide strings may be out of the question.
+Thus, the current ROS 2 design for wide strings makes them optional, defines them as a separate type from regular strings, and recommends against using them for common messages.
 
 ### What is the encoding of the wide string?
 
-There are two main ways that ROS 2.0 can provide for the encoding of a wide string.
-Either ROS 2.0 can define exactly what the encoding will be for all strings, or it can allow the user to specify the encoding when handing it to ROS 2.0.
+There are two main ways that ROS 2 can provide for the encoding of a wide string.
+Either ROS 2 can define exactly what the encoding will be for all strings, or it can allow the user to specify the encoding when handing it to ROS 2.
 There are pros and cons to each approach.
 
-**ROS 2.0 defines the encoding**
+**ROS 2 defines the encoding**
 
 Pros:
 
@@ -97,7 +97,7 @@ Pros:
 
 Cons:
 
-* If the user-level code uses a different encoding, the user is responsible for doing a conversion to the ROS 2.0 defined encoding.
+* If the user-level code uses a different encoding, the user is responsible for doing a conversion to the ROS 2 defined encoding.
   This can involve some runtime cost.
 
 **User defines the encoding**
@@ -108,9 +108,9 @@ Pros:
 
 Cons:
 
-* The user must always tell ROS 2.0 what encoding the data is in.
+* The user must always tell ROS 2 what encoding the data is in.
 * The encoding needs to be transmitted on the wire to the other side.
-* It is not clear how ROS 2.0 will transmit the encoding.
+* It is not clear how ROS 2 will transmit the encoding.
   Fixed list?
   Which encodings go into the list?
 
@@ -118,17 +118,17 @@ While a user defined encoding looks somewhat attractive at first, the downsides 
 The downsides also mean that any program that wants to parse ROS 2 messages (or bag files) may potentially have to deal with many different encodings.
 Additionally, Unicode (and in particular, UTF-8) are very commonplace now, while other encodings are becoming more esoteric.
 Even earlier Unicode (UTF-16 and UTF-32) encodings are essentially deprecated in favor of UTF-8.
-For these reasons, the current design of the ROS 2.0 wide string is to use a UTF-8 encoding for all strings.
+For these reasons, the current design of the ROS 2 wide string is to use a UTF-8 encoding for all strings.
 
-### What does the API look like to a user of ROS 2.0?
+### What does the API look like to a user of ROS 2?
 
 #### Python 3
 
 Python 3 splits byte arrays from strings pretty cleanly.
 Thus, in Python 3, a string is a sequence of characters, where each character can take 1 or more bytes.
 Byte arrays are sequences of bytes.
-Thus, the ROS 2.0 API for dealing with wide strings (such as the publish API) will take just a string type in, and encode it as utf-8.
-The ROS 2.0 API for dealing with regular strings will take a string type in, and encode it as ASCII.
+Thus, the ROS 2 API for dealing with wide strings (such as the publish API) will take just a string type in, and encode it as utf-8.
+The ROS 2 API for dealing with regular strings will take a string type in, and encode it as ASCII.
 
 **Example**
 
@@ -176,7 +176,7 @@ Thus, the API looks exactly the same as it would for the String type.
 
 C++ doesn't have good built-in support for wide strings.
 Using wchar_t is generally not a good option, as wchar_t has different sizes on different platforms (2 bytes on Windows, 4 bytes on Linux).
-Thus, ROS 2.0 will define a new type to deal with wide strings.
+Thus, ROS 2 will define a new type to deal with wide strings.
 The APIs that deal with wide strings will expect this new type to be passed in.
 
 **Example**
@@ -224,7 +224,7 @@ The publisher takes in types of utf8_string, and generates the correct data on t
 ### Bounded wide strings
 
 A note on bounded wide strings.
-ROS 2.0 allows for "bounded" strings and wide strings.
+ROS 2 allows for "bounded" strings and wide strings.
 These are strings that can be no longer than their bounded number.
 In the case of strings, the width of a character == the width of a byte in most cases, so the number of bytes in a bounded string is generally the bound (plus 1 for the NULL-termination).
 Wide strings are a little bit different.
@@ -233,7 +233,7 @@ Thus the maximum number of bytes the bounded wide string can be may be, and most
 
 ## Summary
 
-To summarize, the current ROS 2.0 design for wide strings:
+To summarize, the current ROS 2 design for wide strings:
 
 * Maps wide characters onto the DDS type wchar.
   This in turn maps wide strings on the DDS type wstring.
@@ -242,4 +242,4 @@ To summarize, the current ROS 2.0 design for wide strings:
 * Recommends against using wide strings for common messages.
 * Defines the encoding for all wide string to be UTF-8.
 * For python the APIs that deal with wstrings will take a regular str type in.
-* For C++, ROS 2.0 will define a new type to deal with wstrings.
+* For C++, ROS 2 will define a new type to deal with wstrings.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -64,6 +64,10 @@ To be compatible, a ROS message `string` field must not contain zero bytes, and 
 This restriction will be enforced.
 
 ## Unicode Strings Across ROS 1 Bridge
+
+**Note:** This section has not yet been implemented.
+See [ros2/ros1_bridge#203](https://github.com/ros2/ros1_bridge/issues/203).
+
 Since ROS 1 and 2 both allow `string` to be UTF-8, the ROS 1 bridge will pass values unmodified between them.
 If a message with a string field fails to serialize because the content is not legal UTF-8 then the default behavior will be to drop the entire message.
 Other strategies like replacing invalid bytes could unintentionally change the meaning, so they will be opt-in if available at all.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -88,7 +88,7 @@ Generated code for ROS 2 messages will automatically handle the conversion when 
 
 Message definitions may restrict the maximum size of a string.
 These are referred to as bounded strings.
-Their purpose is to restrinct the amount of memory used, so the bounds must be specified as units of memory.
+Their purpose is to restrict the amount of memory used, so the bounds must be specified as units of memory.
 If a `string` field is bounded then the size is given in bytes.
 Similarly the size of a bounded `wstring` is to be specified in words.
 It is the responsibility of whoever populates a bounded `string` or `wstring` to make sure it contains whole code points only.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -131,43 +131,29 @@ Bytes of a known encoding should be converted to a `str` using [bytes.decode](ht
 
 **Example**
 
-```
+```python
 import sys
 from time import sleep
 
 import rclpy
-
 from rclpy.qos import qos_profile_default
-
 from std_msgs.msg import WString
 
-def main(args=None):
-    if args is None:
-        args = sys.argv
 
-    rclpy.init(args)
+if __name__ == '__main__':
+    rclpy.init(sys.argv)
 
     node = rclpy.create_node('talker')
 
     chatter_pub = node.create_publisher(WString, 'chatter', qos_profile_default)
 
-    msg = String()
-
-    i = 1
-    while True:
-        msg.data = 'Hello World: {0}'.format(i)
-        i += 1
-        print('Publishing: "{0}"'.format(msg.data))
-        chatter_pub.publish(msg)
-        # TODO(wjwwood): need to spin_some or spin_once with timeout
-        sleep(1)
-
-
-if __name__ == '__main__':
-    main()
+    msg = WString()
+    msg.data = 'Hello World' + bytes([0x00, 0x00, 0x26, 0x3A]).decode('utf-32-be')
+    print('Publishing: "{0}"'.format(msg.data))
+    chatter_pub.publish(msg)
+    node.destroy_node()
+    rclpy.shutdown()
 ```
-
-This code looks almost identical to the same demo for String.
 
 ### C++
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -1,9 +1,8 @@
 ---
 layout: default
-title: WideStrings
+title: Unicode Support
 abstract:
-  Some ROS2 users would like to use multi-byte characters for topic data, suitable for supporting multi-byte languages.
-  This article lays out the problem, and explores potential solutions to this problem.
+  This article desribes how ROS 2 will support multi-byte character sets.
 author: '[Chris Lalancette](https://github.com/clalancette)'
 published: true
 ---

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -138,7 +138,7 @@ if __name__ == '__main__':
     chatter_pub = node.create_publisher(WString, 'chatter', qos_profile_default)
 
     msg = WString()
-    msg.data = 'Hello Wörld' + bytes([0x00, 0x00, 0x26, 0x3A]).decode('utf-32-be')
+    msg.data = 'Hello Wörld'
     print('Publishing: "{0}"'.format(msg.data))
     chatter_pub.publish(msg)
     node.destroy_node()

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -59,18 +59,20 @@ This purpose is to allow ROS 2 nodes to comminicate with non-ROS DDS entities us
 The encoding of data in this type should be UTF-16 to match DDS-XTYPES 1.2.
 Since both UTF-8 and UTF-16 can encode the same code points, new ROS 2 messages should prefer `string` over `wstring`.
 
-## Encodings are Recommendations
-The choice of UTF-8 or UTF-16 for `string` and `wstring` are recommendations.
-A `string` or `wstring` field is allowed to be populated and published with an unknown encoding.
-If subscriber receives a string containing an unknown ncoding then it is up to the subscriber how to handle it.
-It could decode it using an encoding that has been agreed to out of band.
+## Encodings are Required but not Guaranteed to be Enforced
+The choice of UTF-8 or UTF-16 for `string` and `wstring` are required, but it is up to the rmw implementation to enfoce them.
+They are not guaranteed to be enforced because it is unknown if it would be a significant performance hit on resource constrained systems.
+Further, users writing defensive code would already check that a string contains valid data after receiving it.
+
+If a `string` or `wstring` field is populated with the wrong encoding then the behavior is undefined.
+It is possible the middleware may allow invalid data to be passed through to subscribers.
+Each subscriber is responsible for detecting and deciding how to handle it.
+For example, it could decode it using an encoding that has been agreed to out of band.
 Other subscribers like `ros2 topic echo` may echo the bytes in hexadecimal.
 
-In practice using different encodings may not be possible.
 The IDL specification forbids `string` from containing `NULL` values.
 For compatibility a ROS message `string` field must not contain zero bytes, and a `wstring` field must not contain zero words.
-An encoding like UTF-32 cannot be used since it may have zero bytes or words in a code point.
-If UTF-32 encoded strings need to be transmitted then one should either convert to UTF-8 and use a `string` or use a `uint32` array.
+This restriction is enforced.
 
 <div class="alert alert-warning" markdown="1">
   <b>TODO:</b> Can ROS 1 publish a string with NULL bytes?

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -1,0 +1,264 @@
+---
+layout: default
+title: WideStrings
+abstract:
+  Some ROS2 users would like to use multi-byte characters for topic data, suitable for supporting multi-byte languages.  This article lays out the problem, and explores potential solutions to this problem.
+author: '[Chris Lalancette](https://github.com/clalancette)'
+published: true
+---
+
+- This will become a table of contents (this text will be scraped).
+{:toc}
+
+# {{ page.title }}
+
+<div class="abstract" markdown="1">
+{{ page.abstract }}
+</div>
+
+Original Author: {{ page.author }}
+
+## Background
+
+ROS2 currently supports the concept of strings, which are sequences of single-byte
+characters.  When working with ROS 2.0 topic data, some users would like to use multi-byte
+characters (e.g. UTF-8) for their topic data.  This article explores the
+problem and the possible solutions.  Note that this article specifically does
+not talk about binary data, as that is already handled by using uint8_t arrays.
+It also does not talk about using multi-byte characters for the topic *names*,
+as this is disallowed by the DDS specification.
+
+## Multi-byte character background
+
+Before delving into ROS 2.0 specifics, some time should be spent discussing multi-byte
+characters in general.  What is meant by multi-byte characters?  The original ASCII
+character set only provided for printable characters using binary sequences 0 to 127.
+Several extensions were made to this to use 128-255, but that approach only extended the
+character set to be able to cover a few more languages.  Several other encodings were
+created as the need arose, and it became clear by the 1990's that a worldwide standard
+was required.  Thus, Unicode was created to be a single specification that could cover
+all of the languages of the world.  The early versions of Unicode actually failed to
+live up to this expectation, and some of those early versions of Unicode are still
+baked into widely used software (Microsoft Windows, Java, etc).  Later on, the Unicode
+standard evolved to truly be able to cover the languages of the entire world, and this
+is what should generally be used for new designs.  As a side benefit, the newer versions of
+Unicode (UTF-8) are backwards compatible with ASCII.  There is a lot of history here, and
+things are much more complicated then the brief introduction above.  For more information,
+the following links provide introductory material:
+
+* [http://kunststube.net/encoding/](http://kunststube.net/encoding/)
+* [http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms](http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms)
+* [http://www.diveintopython3.net/strings.html](http://www.diveintopython3.net/strings.html)
+* [http://stackoverflow.com/questions/402283/stdwstring-vs-stdstring](http://stackoverflow.com/questions/402283/stdwstring-vs-stdstring)
+
+The rest of this document is generally going to assume Unicode, unless stated otherwise.
+
+## Introducing Wide Strings
+To support multi-byte characters, ROS 2.0 will introduce the concept of a wide string.  There are a
+few basic questions to answer on how a wide string will be integrated into ROS 2.0:
+
+* What is the size impact of the wide string?
+* What is the encoding of the wide string?
+* What does the API look like to a user of ROS 2.0?
+
+Each of these questions will be examined in more detail below.
+
+### What is the size impact of the wide string?
+
+There are 2 parts to this question.  One is how the wide string is mapped onto the underlying
+DDS implementation, which defines how large messages will be on-the-wire (and on disk).  The
+other part of the question deals with the runtime impact (in terms of speed and code size) of
+having to deal with wide strings.
+
+**Mapping onto the DDS implementation**
+
+There are a couple of different ways that a wide string could be mapped onto a
+DDS implementation.  The first way it could be mapped is onto a uint8_t byte
+array.  While this would work, it has the downside that the byte array would be
+"opaque", and any introspection tools into DDS wouldn't see anything but a stream
+of bytes.  The second way it could be mapped is onto the "wchar/wstring" type
+defined by the DDS specification.  The DDS specification itself doesn't define
+a size for wchar, but the X-Types specification (for DDS introspection) does
+say that a wchar should be mapped onto a Char32.  Thus, all known encodings
+would fit into a wchar, and DDS introspection tools could look into wstrings.
+Thus, the current design of wide strings map onto wchar DDS types.
+
+**Runtime impact of wide string**
+
+Dealing with wide strings puts more strain on the software of a system, both in
+terms of speed and in terms of code size.  This is felt most acutely when talking
+about small microcontrollers, where both flash size (code space) and performance
+(processor speed) are at a premium.  Some of the common encodings (including UTF-8)
+are defined as being variable width, meaning that a character can take 1, 2, or 4
+characters to represent.  These encoding also typically have the ability to combine
+one character with the next in non-trivial ways.  As one of the goals of ROS 2.0
+is to support small, constrained systems, dealing with wide strings may be out of
+the question.  Thus, the current ROS 2.0 design for wide strings makes them optional,
+defines them as a separate type from regular strings, and recommends against
+using them for common messages.
+
+### What is the encoding of the wide string?
+
+There are two main ways that ROS 2.0 can provide for the encoding of a wide string.  Either
+ROS 2.0 can define exactly what the encoding will be for all strings, or it can allow the
+user to specify the encoding when handing it to ROS 2.0.  There are pros and cons to each
+approach.
+
+**ROS 2.0 defines the encoding**
+
+Pros:
+
+* All strings known to be in the same encoding.
+
+Cons:
+
+* If the user-level code uses a different encoding, the user is responsible
+for doing a conversion to the ROS 2.0 defined encoding.  This can involve
+some runtime cost.
+
+**User defines the encoding**
+
+Pros:
+
+* No conversions necessary for user-to-ROS 2 API.
+
+Cons:
+
+* The user must always tell ROS 2.0 what encoding the data is in.
+* The encoding needs to be transmitted on the wire to the other side.
+* It is not clear how ROS 2.0 will transmit the encoding.  Fixed list?  Which
+encodings go into the list?
+
+While a user defined encoding looks somewhat attractive at first, the downsides
+to it make it difficult to determine exactly which encodings are in use.  The
+downsides also mean that any program that wants to parse ROS 2 messages (or bag
+files) may potentially have to deal with many different encodings.  Additionally,
+Unicode (and in particular, UTF-8) are very commonplace now, while other encodings
+are becoming more esoteric.  Even earlier Unicode (UTF-16 and UTF-32) encodings are
+essentially deprecated in favor of UTF-8.  For these reasons, the current design of
+the ROS 2.0 wide string is to use a UTF-8 encoding for all strings.
+
+### What does the API look like to a user of ROS 2.0?
+
+#### Python 3
+
+Python 3 splits byte arrays from strings pretty cleanly.  Thus, in Python 3, a
+string is a sequence of characters, where each character can take 1 or more bytes.
+Byte arrays are sequences of bytes.  Thus, the ROS 2.0 API for dealing with wide strings
+(such as the publish API) will take just a string type in, and encode it as utf-8.
+The ROS 2.0 API for dealing with regular strings will take a string type in, and
+encode it as ASCII.
+
+**Example**
+
+```
+import sys
+from time import sleep
+
+import rclpy
+
+from rclpy.qos import qos_profile_default
+
+from std_msgs.msg import WString
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    rclpy.init(args)
+
+    node = rclpy.create_node('talker')
+
+    chatter_pub = node.create_publisher(WString, 'chatter', qos_profile_default)
+
+    msg = String()
+
+    i = 1
+    while True:
+        msg.data = 'Hello World: {0}'.format(i)
+        i += 1
+        print('Publishing: "{0}"'.format(msg.data))
+        chatter_pub.publish(msg)
+        # TODO(wjwwood): need to spin_some or spin_once with timeout
+        sleep(1)
+
+
+if __name__ == '__main__':
+    main()
+```
+
+Notice that this code looks almost identical to the same demo for String.  That's because
+in python, the characters in the string and the byte representation are cleanly
+separated.  Thus, the API looks exactly the same as it would for the String type.
+
+#### C++
+
+C++ doesn't have good built-in support for wide strings.  Using wchar_t is generally
+not a good option, as wchar_t has different sizes on different platforms (2 bytes on
+Windows, 4 bytes on Linux).  Thus, ROS 2.0 will define a new type to deal with wide strings.
+The APIs that deal with wide strings will expect this new type to be passed in.
+
+**Example**
+
+```
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/w_string.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::node::Node::make_shared("talker");
+
+  rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+  custom_qos_profile.depth = 7;
+
+  auto chatter_pub = node->create_publisher<std_msgs::msg::WString>("chatter", custom_qos_profile);
+
+  rclcpp::WallRate loop_rate(2);
+
+  auto msg = std::make_shared<std_msgs::msg::WString>();
+  auto i = 1;
+
+  while (rclcpp::ok()) {
+    utf8_string hello("Hello World: " + std::to_string(i++));
+    msg->data = hello;
+    std::cout << "Publishing: '" << msg->data.cpp_str() << "'" << std::endl;
+    chatter_pub->publish(msg);
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+  }
+
+  return 0;
+}
+```
+
+Here, ROS 2 has implemented a new type called "utf8_string" (this is still to be implemented,
+and the name may change).  The publisher takes in types of utf8_string, and generates the
+correct data on the wire.
+
+### Bounded wide strings
+
+A note on bounded wide strings.  ROS 2.0 allows for "bounded" strings and wide strings.  These
+are strings that can be no longer than their bounded number.  In the case of strings, the
+width of a character == the width of a byte in most cases, so the number of bytes in a bounded
+string is generally the bound (plus 1 for the NULL-termination).  Wide strings are a little bit different.
+When dealing with bounded wide strings, the bound is on the number of characters, not bytes.  Thus
+the maximum number of bytes the bounded wide string can be may be, and most likely will be, larger
+than the number of characters.
+
+## Summary
+
+To summarize, the current ROS 2.0 design for wide strings:
+
+* Maps wide characters onto the DDS type wchar.  This in turn maps wide strings on the DDS type wstring.
+* Allows them to be optionally supported by an implementation.
+* Defines wide strings as a separate type from strings.
+* Recommends against using wide strings for common messages.
+* Defines the encoding for all wide string to be UTF-8.
+* For python the APIs that deal with wstrings will take a regular str type in.
+* For C++, ROS 2.0 will define a new type to deal with wstrings.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -50,7 +50,7 @@ Since both UTF-8 and UTF-16 can encode the same code points, new ROS 2 messages 
 
 ## Encodings are Required but not Guaranteed to be Enforced
 `string` and `wstring` are required to be UTF-8 and UTF-16, but the requirement may not be enforced.
-Since ROS 2 is targeting resource constrained systems, it is left to the rmw implementation to choose whether or not to enforce the encoding.
+Since ROS 2 is targeting resource constrained systems, it is left to the rmw implementation to choose whether to enforce the encoding.
 Further, since many users will write code to check check that a string contains valid data, checking the encoding may not be necessary in some cases.
 
 If a `string` or `wstring` field is populated with the wrong encoding then the behavior is undefined.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -20,32 +20,22 @@ Original Author: {{ page.author }}
 
 ## Background
 
-ROS2 currently supports the concept of strings, which are sequences of single-byte characters.
-When working with ROS 2 topic data, some users would like to use multi-byte characters (e.g. UTF-8) for their topic data.
-This article explores the problem and the possible solutions.
-Note that this article specifically does not talk about binary data, as that is already handled by using uint8_t arrays.
-It also does not talk about using multi-byte characters for the topic *names*, as this is disallowed by the DDS specification.
+Some users would like to send text data in languages that cannot be represented by ascii characters.
+Currently ROS 1 only supports ASCII data in the string field but [allows users to populate it with UTF-8](http://wiki.ros.org/msg).
+This article describes how ROS 2 will support sending multi-byte character data using the [Unicode](https://en.wikipedia.org/wiki/Unicode) standard.
+It also describes how such data will be sent over the ROS 1 bridge.
 
-## Multi-byte character background
+Note that topic names cannot use multi-byte characters as they are disallowed by the DDS specification.
+See the [topic and service name](/articles/topic_and_service_names.html) design document for more information.
 
-Before delving into ROS 2 specifics, some time should be spent discussing multi-byte characters in general.
-What is meant by multi-byte characters?
-The original ASCII character set only provided for printable characters using binary sequences 0 to 127.
-Several extensions were made to this to use 128-255, but that approach only extended the character set to be able to cover a few more languages.
-Several other encodings were created as the need arose, and it became clear by the 1990's that a worldwide standard was required.
-Thus, Unicode was created to be a single specification that could cover all of the languages of the world.
-The early versions of Unicode actually failed to live up to this expectation, and some of those early versions of Unicode are still baked into widely used software (Microsoft Windows, Java, etc).
-Later on, the Unicode standard evolved to truly be able to cover the languages of the entire world, and this is what should generally be used for new designs.
-As a side benefit, the newer versions of Unicode (UTF-8) are backwards compatible with ASCII.
-There is a lot of history here, and things are much more complicated then the brief introduction above.
-For more information, the following links provide introductory material:
+The following links have more information about multi-byte characters and the history of character encodings.
 
 * [http://kunststube.net/encoding/](http://kunststube.net/encoding/)
 * [http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms](http://stackoverflow.com/questions/4588302/why-isnt-wchar-t-widely-used-in-code-for-linux-related-platforms)
 * [http://www.diveintopython3.net/strings.html](http://www.diveintopython3.net/strings.html)
 * [http://stackoverflow.com/questions/402283/stdwstring-vs-stdstring](http://stackoverflow.com/questions/402283/stdwstring-vs-stdstring)
+* [https://utf8everywhere.org/](http://utf8everywhere.org/)
 
-The rest of this document is generally going to assume Unicode, unless stated otherwise.
 
 ## Unicode Characters in Strings
 ROS 1 says string fields are to contain ASCII encoded data, but allows UTF-8.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -99,7 +99,7 @@ Generated code for ROS 2 messages will automatically handle the conversion when 
 
 ### Bounded wide strings
 
-Embedded systems accepting strings may use message definitions that restrict the maximum size of a string.
+Message definitions may restrict the maximum size of a string.
 These are referred to as bounded strings.
 Their purpose is to restrinct the amount of memory used, so the bounds must be specified as units of memory.
 If a `string` field is bounded then the size is given in bytes.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -45,7 +45,7 @@ To be compatibile with both, in ROS 2 the content of a `string` is expected to b
 
 ## Wide Strings
 ROS 2 messages will have a new [primitive field type](/articles/interface_definition.html) `wstring`.
-This purpose is to allow ROS 2 nodes to comminicate with non-ROS DDS entities using an IDL containing a `wstring` field.
+The purpose is to allow ROS 2 nodes to communicate with non-ROS DDS entities using an IDL containing a `wstring` field.
 The encoding of data in this type should be UTF-16 to match DDS-XTYPES 1.2.
 Since both UTF-8 and UTF-16 can encode the same code points, new ROS 2 messages should prefer `string` over `wstring`.
 
@@ -147,7 +147,7 @@ if __name__ == '__main__':
 
 ### C++
 
-In c++ wsing `wchar_t` has different sizes on different platforms (2 bytes on Windows, 4 bytes on Linux).
+In C++ wstring `wchar_t` has different sizes on different platforms (2 bytes on Windows, 4 bytes on Linux).
 Instead ROS 2 will use `char16_t` for characters of wide strings, and `std::u16string` for wide strings themselves.
 
 **Example**

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -110,7 +110,7 @@ Partial code points are indistinuguishable from invalid code points, so a bounde
 ## Runtime impact of wide string
 
 Dealing with wide strings puts more strain on the software of a system, both in terms of speed and code size.
-UTF-8 and UTF-16 are both variable width encodings, meaning a code point can take 1 (UTF-8 only), 2, or 4 bytes to represent.
+UTF-8 and UTF-16 are both variable width encodings, meaning a code point can take 1 to 4 bytes depending on the encoding.
 It may take multiple code points to represent a single user perceived character.
 One of the goals of ROS 2 is to support microcontrollers that are contrained by both code size and processor speed.
 Some wide string operations like splitting a string on a user perceived character may not be possible on these devices.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -189,3 +189,9 @@ int main(int argc, char * argv[])
   return 0;
 }
 ```
+
+#### Microsoft Visual Studio and byte order marks
+
+Note that C++ source files containing unicode characters must begin with a [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark).
+Failure to do so can result in an incorrect encoding of the characters.
+For an example, see [ros2/system_tests#362](https://github.com/ros2/system_tests/pull/362#issue-277436162)

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -54,8 +54,8 @@ Since ROS 2 is targeting resource constrained systems, it is left to the rmw imp
 Further, since many users will write code to check that a string contains valid data, checking again in lower layers may not be necessary in some cases.
 
 If a `string` or `wstring` field is populated with the wrong encoding then the behavior is undefined.
-It is possible the rmw implementation may allow invalid data to be passed through to subscribers.
-Each subscriber is responsible for detecting invalid data and deciding how to handle it.
+It is possible the rmw implementation may allow invalid strings to be passed through to subscribers.
+Each subscriber is responsible for detecting invalid strings and deciding how to handle them.
 For example, subscribers like `ros2 topic echo` may echo the bytes in hexadecimal.
 
 The IDL specification forbids `string` from containing `NULL` values.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     chatter_pub = node.create_publisher(WString, 'chatter', qos_profile_default)
 
     msg = WString()
-    msg.data = 'Hello World' + bytes([0x00, 0x00, 0x26, 0x3A]).decode('utf-32-be')
+    msg.data = 'Hello Wörld' + bytes([0x00, 0x00, 0x26, 0x3A]).decode('utf-32-be')
     print('Publishing: "{0}"'.format(msg.data))
     chatter_pub.publish(msg)
     node.destroy_node()

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -194,5 +194,5 @@ int main(int argc, char * argv[])
 #### Microsoft Visual Studio and byte order marks
 
 Note that C++ source files containing unicode characters must begin with a [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark).
-Failure to do so can result in an incorrect encoding of the characters.
+Failure to do so can result in an incorrect encoding of the characters on Windows.
 For an example, see [ros2/system_tests#362](https://github.com/ros2/system_tests/pull/362#issue-277436162)

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -69,7 +69,7 @@ Other strategies like replacing invalid bytes could unintentionally change the m
 
 If a ROS 2 message has a field of type `wstring` then the bridge will attempt to convert it from UTF-16 to UTF-8.
 The resulting UTF-8 encoded string will be published as a `string` type.
-If the conversion fails then the bridge will not publish the message.
+If the conversion fails then the bridge will by default not publish the message.
 
 ## Size of a Wide String
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -21,7 +21,7 @@ Original Author: {{ page.author }}
 
 ## Background
 
-Some users would like to send text data in languages that cannot be represented by ascii characters.
+Some users would like to send text data in languages that cannot be represented by ASCII characters.
 Currently ROS 1 only supports ASCII data in the string field but [allows users to populate it with UTF-8](http://wiki.ros.org/msg).
 
 Note that topic names cannot use multi-byte characters as they are disallowed by the DDS specification.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -79,7 +79,8 @@ This restriction is enforced.
 
 ## Unicode Strings Across ROS 1 Bridge
 Since ROS 1 and 2 both allow `string` to be UTF-8, the ROS 1 bridge will pass values unmodified between them.
-If a message sent from ROS 2 to ROS 1 fails to serialize because a string contains values that are not legal UTF-8 then it won't be published by the bridge.
+If a message with a string field fails to serialize because the content is not legal UTF-8 then the default behavior will be to drop the entire message.
+Other strategies like replacing invalid bytes could unintentionally change the meaning, so they will be opt-in if available at all.
 
 If a ROS 2 message has a field of type `wstring` then the bridge will attempt to convert it from UTF-16 to UTF-8.
 The resulting UTF-8 encoded string will be published as a `string` type.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -59,12 +59,8 @@ Each subscriber is responsible for detecting invalid data and deciding how to ha
 For example, subscribers like `ros2 topic echo` may echo the bytes in hexadecimal.
 
 The IDL specification forbids `string` from containing `NULL` values.
-For compatibility a ROS message `string` field must not contain zero bytes, and a `wstring` field must not contain zero words.
+To be compatible, a ROS message `string` field must not contain zero bytes, and a `wstring` field must not contain zero words.
 This restriction will be enforced.
-
-<div class="alert alert-warning" markdown="1">
-  <b>TODO:</b> Can ROS 1 publish a string with NULL bytes?
-</div>
 
 ## Unicode Strings Across ROS 1 Bridge
 Since ROS 1 and 2 both allow `string` to be UTF-8, the ROS 1 bridge will pass values unmodified between them.

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -117,8 +117,8 @@ Some wide string operations like splitting a string on a user perceived characte
 
 However, whole string equality checking is the same whether using wide strings or not.
 Further splitting a UTF-8 string on an ASCII character is identical to splitting an ASCII character on an ASCII string.
-If a microcontroller must do other types of string manipluation, then a `string` type should still be used.
-Code in the subscriber callback should stop processing a message when it encounters a byte greater than 127 in a `string` field.
+If code on a microcontroller must do string manipluation then it could assert that a `string` only contains ASCII data.
+It should be computationally inexpensive for it to stop processing a string when it encounters a byte greater than 127.
 
 ## What does the API look like to a user of ROS 2?
 

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -125,7 +125,6 @@ Code in the subscriber callback should stop processing a message when it encount
 ### Python 3
 
 In Python 3 a string is a sequence of characters where each character can take 1 or more bytes.
-Byte arrays are sequences of bytes.
 Thus the ROS 2 API for dealing with `wstring` will take a string type in internally and convert it to UTF-16.
 
 **Example**

--- a/articles/WideStrings.md
+++ b/articles/WideStrings.md
@@ -65,12 +65,13 @@ This restriction will be enforced.
 
 ## Unicode Strings Across ROS 1 Bridge
 
-**Note:** This section has not yet been implemented.
-See [ros2/ros1_bridge#203](https://github.com/ros2/ros1_bridge/issues/203).
-
 Since ROS 1 and 2 both allow `string` to be UTF-8, the ROS 1 bridge will pass values unmodified between them.
 If a message with a string field fails to serialize because the content is not legal UTF-8 then the default behavior will be to drop the entire message.
 Other strategies like replacing invalid bytes could unintentionally change the meaning, so they will be opt-in if available at all.
+
+
+**Note:** Bridging `wstring` fields is not yet implemented.
+See [ros2/ros1_bridge#203](https://github.com/ros2/ros1_bridge/issues/203).
 
 If a ROS 2 message has a field of type `wstring` then the bridge will attempt to convert it from UTF-16 to UTF-8.
 The resulting UTF-8 encoded string will be published as a `string` type.


### PR DESCRIPTION
This incorporates a bunch of research and thinking I've done about the problem, as well as feedback from people internally.  Note a few things about this article:

1.  It takes the stance that we should have a wide string type separate from the string type.

2.  It takes the stance that we should use UTF-8.  We haven't 100% decided this, but it is the most logical choice; almost all other encodings are deprecated at this point.

3.  It takes the stance that we should map the wide string onto the DDS concept of a wchar.  As Mikael pointed out, the XTypes spec on top of DDS mandates that wchar == Char32.  While the spec does *not* mandate what size Char32 is, it would be pretty surprising if it would be anything but 32 bits.  The other option we have here is to map the wide string on the DDS concept of uint8, which would shrink the size on the wire.  As it stands right now, none of the tools I looked at (including the RTI Connext tools) have the ability to properly display a wchar/wstring, so there is currently no compelling reason to go with wchar.  Still TBD.

4.  The C++ example below is really simple.  There actually exists a library called "utf8" that has a utf8_string class that behaves a lot like std::string, and that is what the example below uses.  What other APIs do we think we would need to model?

connects to  ros2/rosidl#208