### PR TITLE
Clarify that support for non-ROS packages is a requirement

### DIFF
--- a/articles/101_build_tool.md
+++ b/articles/101_build_tool.md
@@ -34,7 +34,8 @@ This article describes the steps from the current build tools used in the ROS ec
 
 The goal of the build tool is to build a set of packages with a single invocation automating the process.
 It should work with ROS 1 packages as well as ROS 2 packages which provide the necessary information in their manifest files.
-It would be great if the tool could also be used to build other packages (e.g. Gazebo including its dependencies).
+It should also work with packages that do not provide manifest files themselves, given that the meta information is externally provided.
+This will allow the build tool to be utilized for non-ROS dependencies of ROS packages (e.g. Gazebo including its dependencies).
 
 ### Out of Scope
 


### PR DESCRIPTION
The key point to make here is that we are not just supporting other packages because it would be nice to do so, but because we need it.