### PR TITLE
Correct examples for valid rostopics with underscores.

### DIFF
--- a/articles/140_topic_and_service_name_mapping.md
+++ b/articles/140_topic_and_service_name_mapping.md
@@ -67,8 +67,6 @@ For convenience here is a summary of all rules for topic and service names in RO
 - must not end with a forward slash (`/`)
 - must not contain any number of repeated forward slashes (`/`)
 - must separate a tilde (`~`) from the rest of the name with a forward slash (`/`), i.e. `~/foo` not `~foo`
-- must not end with an underscore (`_`)
-- must not contain an uderscore (`_`) preceding a forward slash (`/`)
 - must have balanced curly braces (`{}`) when used, i.e. `{sub}/foo` but not `{sub/foo` nor `/foo}`
 
 The content of substitutions, i.e. the string in side of balanced curly braces (`{}`), follow very similar rules to names.
@@ -105,15 +103,15 @@ A relative name `foo/bar` could would be represented (as a topic) with `rostopic
 
 For example, these are valid names:
 
-| `foo`       | `abc123`            | `_foo`               | `Foo`        | `BAR`            |
-| `~`         | `foo/bar`           | `~/foo`              | `{foo}_bar`  | `foo/{ping}/bar` |
-| `foo/_bar`  | `rosservice:///foo` | `rostopic://foo/bar` |              |                  |
+| `foo`      | `abc123`   | `_foo`  | `Foo`               | `BAR`                |
+| `~`        | `foo/bar`  | `~/foo` | `{foo}_bar`         | `foo/{ping}/bar`     |
+| `foo/_bar` | `foo_/bar` | `foo_`  | `rosservice:///foo` | `rostopic://foo/bar` |
 
 But these are not valid names:
 
 | `123abc`    | `123`  | `foo bar` | ` `        | `foo//bar` |
-| `foo_/bar`  | `~foo` | `foo~`    | `foo~/bar` | `foo/~bar` |
-| `foo/~/bar` | `foo/` | `/~`      |            |            |
+| `/~`        | `~foo` | `foo~`    | `foo~/bar` | `foo/~bar` |
+| `foo/~/bar` | `foo/` |           |            |            |
 
 These are some valid fully qualified names:
 
@@ -159,8 +157,6 @@ Topic and service name tokens:
 - may use alphanumeric characters (`[0-9|a-z|A-Z]`), underscores (`_`), and/or balanced curly braces (`{}`)
 
 - must not start with numeric characters (`[0-9]`)
-
-- must not end with an underscore (`_`)
 
 - may be a single tilde character (`~`)
 

--- a/articles/140_topic_and_service_name_mapping.md
+++ b/articles/140_topic_and_service_name_mapping.md
@@ -67,6 +67,8 @@ For convenience here is a summary of all rules for topic and service names in RO
 - must not end with a forward slash (`/`)
 - must not contain any number of repeated forward slashes (`/`)
 - must separate a tilde (`~`) from the rest of the name with a forward slash (`/`), i.e. `~/foo` not `~foo`
+- must not end with an underscore (`_`)
+- must not contain an uderscore (`_`) preceding a forward slash (`/`)
 - must have balanced curly braces (`{}`) when used, i.e. `{sub}/foo` but not `{sub/foo` nor `/foo}`
 
 The content of substitutions, i.e. the string in side of balanced curly braces (`{}`), follow very similar rules to names.
@@ -157,6 +159,8 @@ Topic and service name tokens:
 - may use alphanumeric characters (`[0-9|a-z|A-Z]`), underscores (`_`), and/or balanced curly braces (`{}`)
 
 - must not start with numeric characters (`[0-9]`)
+
+- must not end with an underscore (`_`)
 
 - may be a single tilde character (`~`)
 


### PR DESCRIPTION
The examples in the _Topic and Service name mapping to DDS_ article imply that trailing underscores are not allowed in ROS name tokens (i.e. `foo/_bar` is valid while `foo_/bar` is not).
