### PR TITLE
enhanced time article to include realtime factor

### DIFF
--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -47,14 +47,19 @@ Additionally if the simulation is paused the system can also pause using the sam
 
 A third situation arises with hardware that doesn't have a system clock chip available. 
 Nodes running there need to be notified of the current time so that they can utilize that information to time-stamp their output. 
-(We will assume that nodes running on this type of hardware have accurate frequency counters available that can assist in computing the current time when they have some base time to compound.)
+We will assume that nodes running on this type of hardware have accurate frequency counters available that can assist in computing the current time when they have some base time to compound.
+However, we strongly recommend against broadcasting time over multiple machines.
+Clock synchronization is not the intent of the ROS clock message; it is outside the scope of ROS.
+This is not a viable use case because of network latency.
+Instead, use an existing mechanism to synchronize clocks between systems.
+Even if your mixed system has node-hosting parts with no real-time clock chip, those can still host fake a clock that is synchronized to some other real clock.
+Use quality time synchronizers like chrony or TICSync.
 
 ### Challenges in using abstracted time
 
 There are many algorithms for synchronization and they can typically achieve accuracies which are better than the latency of the network communications between devices on the network.
 However, these algorithms take advantage of assumptions about the constant and continuous nature of time.
-
-Again, this is not the primary intent of synchronizing time between ROS nodes. 
+Again, this is not the primary intent of publishing time between ROS nodes. 
 We need to ensure the ability to manipulate time.
 In some cases, speeding up, slowing down, or pausing time entirely is important for debugging.
 And the ability to support pausing time requires that we not assume that the time values are always increasing.
@@ -63,7 +68,7 @@ When communicating the changes in time propagation, the latencies in the communi
 Any change in the time abstraction must be communicated to the other nodes in the graph, but will be subject to normal network communication latency.
 This inaccuracy is proportional to the latency of communications and also proportional to the increase in the real time factor.
 If very accurate timestamping is required when using the time abstraction, it can be achieved by slowing down the real time factor such that the communication latency is comparatively small.
-Of course we recommend using synchronized system clock sources for live work on nodes spread across multiple devices.
+We recommend using synchronized system clock sources for live work on nodes spread across multiple devices.
 
 The final challenge is that the time abstraction must be able to jump backwards in time, a feature that is useful for log file playback.
 This behavior is similar to a system clock after a negative date change, and requires developers using the time abstraction to make sure their algorithm can deal with the discontinuity.

--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -24,13 +24,19 @@ Original Author: {{ page.author }}
 Many robotics algorithms inherently rely on timing as well as synchronization.
 To this end we require that nodes running in the ROS network have a synchronized clock such that they can accurately report timestamps for events.
 
-There are, however, several other use cases where being able to control the progress of the system is important. We review those next.
+There are, however, several other use cases where being able to control the progress of the system is important; we review those next.
 
 ## Use cases requiring time abstraction
 
+What are the situations where `std::chrono` or other system time mechanisms are insufficient?
+
 When playing back logged data it is often very valuable to support accelerated, slowed, or stepped control over the progress of time.
 This control can allow you to get to a specific time and pause the system so that you can debug it in depth.
-It is possible to do this with a log of the sensor data. However, if the sensor data is out of synchronization with the rest of the system, it will break many algorithms.
+Data playback does not just affect a single node.
+All nodes involved in the playback would need the same clock source.
+It is possible to do this with a log of the sensor data. 
+However, if the sensor data is out of synchronization with the rest of the system, it will break many algorithms.
+For example, the transform system (tf) timestamps messages that contain data computed between two different time/data combos.
 
 Another important use case for using an abstracted time source is when you are running logged data against a simulated robot instead of a real robot.
 Depending on the simulation characteristics, the simulator may be able to run much faster than real time or it may need to run much slower.
@@ -39,18 +45,21 @@ Slower than real time simulation is necessary for complicated systems where accu
 Often the simulation is the limiting factor for the system and as such the simulator can be a time source for faster or slower playback.
 Additionally if the simulation is paused the system can also pause using the same mechanism.
 
-A third situation arises with hardware that doesn't have a system clock chip available. Nodes running there need to be notified of the current time so that they can utilize that information to time-stamp their output. We will assume that nodes running on this type of hardware have accurate timers available.
+A third situation arises with hardware that doesn't have a system clock chip available. 
+Nodes running there need to be notified of the current time so that they can utilize that information to time-stamp their output. 
+(We will assume that nodes running on this type of hardware have accurate frequency counters available that can assist in computing the current time when they have some base time to compound.)
 
 ### Challenges in using abstracted time
 
 There are many algorithms for synchronization and they can typically achieve accuracies which are better than the latency of the network communications between devices on the network.
 However, these algorithms take advantage of assumptions about the constant and continuous nature of time.
 
-Again, this is not the primary intent of synchronizing time between ROS nodes. We need to ensure the ability to manipulate time.
+Again, this is not the primary intent of synchronizing time between ROS nodes. 
+We need to ensure the ability to manipulate time.
 In some cases, speeding up, slowing down, or pausing time entirely is important for debugging.
 And the ability to support pausing time requires that we not assume that the time values are always increasing.
 
-When communicating the changes in time propagation, the latencies in the communication network becomes a challenge.
+When communicating the changes in time propagation, the latencies in the communication network become a challenge.
 Any change in the time abstraction must be communicated to the other nodes in the graph, but will be subject to normal network communication latency.
 This inaccuracy is proportional to the latency of communications and also proportional to the increase in the real time factor.
 If very accurate timestamping is required when using the time abstraction, it can be achieved by slowing down the real time factor such that the communication latency is comparatively small.
@@ -58,47 +67,57 @@ Of course we recommend using synchronized system clock sources for live work on 
 
 The final challenge is that the time abstraction must be able to jump backwards in time, a feature that is useful for log file playback.
 This behavior is similar to a system clock after a negative date change, and requires developers using the time abstraction to make sure their algorithm can deal with the discontinuity.
-Appropriate APIs must be provided for to the developer API to enable notifications of jumps in time, both forward and backwards.
+Appropriate APIs must be provided for to the developer API to enable or handle notifications of jumps in time, both forward and backwards.
 
 ### Time Abstractions
 
 There will be at least three versions of these abstractions with the following types, `ROSTime`, `SystemTime`, and `SteadyTime`.
+All abstractions provide/utilize the same API.
 The latter two choices are designed to parallel the [`std::chrono`][] [`system_clock`][] and [`steady_clock`][].
 It is expected that the default choice of time will be to use the `ROSTime` source, however the parallel implementations supporting `steady_clock` and `system_clock` will be maintained for use cases where the alternate time source is required.
 
+#### System Time
+
+System Time pulls the current time from the system clock chip. 
+It provides benefit over Steady Time when all nodes in the system have synchronized system time available or when all nodes run on the same host that contains a system clock chip.
+
+We expect a System Time publisher to throw an error if the system clock resource is not available.
+We expect methods returning the current time to fall back to Steady Time if System Time is not available.
+
 #### Steady Time
 
-Steady Time implies a realtime incrementing source. There is no modern hardware that does not support this option. Steady Time typically begins at system bootup and measures increments using hardware frequency counters.
+Steady Time implies a real-time incrementing source.
+There is no modern hardware or operating system that does not support this option.
+Steady Time typically begins at system bootup and measures increments using hardware frequency counters.
 
 Example use cases for this include hardware drivers which are interacting with peripherals with hardware timeouts and systems lacking a realtime clock chip.
 
-In nodes which require the use of `SteadyTime` or `SystemTime` for interacting with hardware or other peripherals it is expected that they do a best effort to isolate any `SystemTime` or `SteadyTime` information inside their implementation and translate external interfaces to use the ROS time abstraction when communicating over the ROS network.
-
-#### System Time
-
-System Time pulls the current time from the system clock chip. It provides benefit over Steady Time when all nodes in the system have synchronized system time available.
-
-For convenience in these cases we will also provide the same API as above, but use the name `SystemTime`.
-
-We expect a System Time publisher to throw an error if the system clock resource is not available.
-
+In nodes which require the use of `SteadyTime` or `SystemTime` for interacting with hardware or other peripherals, it is expected that they do a best effort to isolate any `SystemTime` or `SteadyTime` information inside their implementation and translate external interfaces to use the ROS time abstraction when communicating over the ROS network.
 
 #### ROS Time
 
 ROS Time derives the current time from the most-recently received clock broadcast message published on the `/clock` topic.
 
-When the ROS time source is active `ROSTime` will return the latest value reported by the Time Source plus the elapsed time since that report multiplied by the real time factor.
+When the ROS Time source is active `ROSTime` will return the latest value reported by the Time Source plus the elapsed time since that report multiplied by the real time factor.
 
 The ROS Time broadcast (clock message) needs to include this information:
-- The current time in nanoseconds
-- The current time multiplier (also called "factor", typically one, but could zero for paused or negative for going backwards)
-- If possible, the system clock time (in nanoseconds) when the message was published
+- The current time (in nanoseconds, epoch depends upon source and should not be needed)
+- The current real time factor (also called the "multiplier", typically a value of one, but could be zero for paused or negative when going backwards).
+- The system clock time (in nanoseconds since the Unix epoch) when the message was created (or -1 if not available)
+
+This message cannot be latched; to use the real time factor you will need to grab a frequency count (aka, start a stopwatch) when the message is received.
+Stale data would make this mechanism fail.
+An exception to this is when all nodes have a system clock available and the message contains the system clock stamp.
+This sytem timestamp could be used to determine the staleness of the "current time" in the message.
+Nodes that publish data before they receive the current time would also be problematic.
+It will be helpful to have the clock publisher publish a new message whenever there is a new subscription added to reduce this period of unknown time.
 
 ### ROS Time Message Sources
 
 - An included (where?) Steady Clock Publisher.
 - An included (where?) System Clock Publisher.
 - An included (where?) Gazebo Plugin.
+- The ROSBag playback engine.
 
 #### Default Time Source
 
@@ -112,16 +131,19 @@ Users can also add callbacks to `Node::time_reversing` and `Node::time_jumping_b
 The developer has the opportunity to register callbacks with the handler to clear any state from their system if necessary before time will be in the past.
 If the time on the clock jumps backwards, a callback handler will be invoked and be required to complete before any calls to the ROS time abstraction report the new time.
 
-The frequency of publishing the `/clock` as well as the granularity are not specified as they are application specific. Assuming they latch one message, they shouldn't need to publish more often than the multiplier changes. If the realtime multiplier cannot be computed, the message will need to be published very frequently. 
+The frequency of publishing the `/clock` as well as the granularity are not specified as they are application-specific. 
+If the realtime multiplier cannot be computed, the message will need to be published very frequently. 
 
 #### Custom Time Source
 
 It is possible that the user may have access to an out-of-band-time source which can provide better performance than the default source the `/clock` topic.
-It might be possible that for their use case a more advanced algorithm would be needed to propagate the simulated time with adequate precision or latency with restricted bandwidth or connectivity.
-The user will be able to switch out the time source for either each instance of their Time object as well as have the ability to override the default for the process.
+It might be possible that, for their particular use case, a more advanced algorithm is needed to propagate the simulated time with adequate precision for latency arising with restricted bandwidth or connectivity.
+The user will be able to switch out the time source for each instance of their Time object as well as have the ability to override the default for the process or node.
 This can be acheived in C++ using the template on the Time object. The RCL package also contains a method to disable `ROSTime`.
 
-It is possible to use an external time source such as GPS as a ROSTime source. When writing this publisher, ensure that you handle jumps in time (both forward and back) and set the realtime multipleir correctly in those situations.
+It is possible to use an external time source such as GPS as a ROS Time source. 
+When writing this publisher, ensure that you handle jumps in time (both forward and back) and set the real time factor correctly in those situations.
+The preferred option is to use the GPS as an TICSync (or IEEE 1588 PTP or, worst case, NTP) time source instead of a ROS Time source; synchronize your system clocks to the GPS unit's atomic clock.
 
 The `SystemTime`, `SteadyTime`, and `ROSTime` API's will be provided by each client library in an idiomatic way, but they may share a common implementation, e.g. provided by `rcl`.
 However, if a client library chooses to not use the shared implementation then it must implement the functionality itself.
@@ -130,7 +152,7 @@ However, if a client library chooses to not use the shared implementation then i
 
 In each implementation will provide `Time`, `Duration`, and `Rate` datatypes, for all three time source abstraction..
 The `Duration` will support a `sleep_for` function as well as a `sleep_until` method.
-The implementation will also provide a `Timer` object which will provide periodic callback functionality for all the abstractions. It will be microsecond-accurate.
+The implementation will also provide a `Timer` object which will provide periodic callback functionality for all the abstractions.
 
 #### RCL implementation
 
@@ -149,9 +171,23 @@ The underlying datatypes will also provide ways to register notifications, howev
 - Decide where and when to autosubscribe to the `/clock` message. Built in to Node? A Node addon or service? Part of the first call to `rcl_node_init`?
 - Decide how to deal with multiple nodes in a single process that all update the one static time (or decide to ditch the static time methods).
 - Decide where to put the out-of-the-box clock publishers.
+- Decide how to deal with nodes publishing data before they receive the current `ROSTime` update.
 - Ensure that there is no reason we can't enable `ROSTime` (with fallbacks) by default.
-- Change the RCL time implementation to call a method on the time source to return the current time (rather than using a field). This is necessary to compute the current time from the realtime factor. Fix the `rcl_get_ros_time` method to use the newly-added current time method.
-- Add an `rcl_time_source_t` (to the RCL project) for `ROSTime`.
+- Change the RCL time implementation (in `rcl_get_ros_time`) to call a method on the time source to return the current time (rather than using a field). This is necessary to compute the current time from the real time factor. 
+- Add an `rcl_time_source_t` (to the RCL project) for `ROSTime` that includes a method to compute the current time.
+
+
+If we decide to opt-in to ROS Time, you might use an interface like this in C++:
+```cpp
+class ROSTimeManager {
+  public:
+    ROSTimeManager(Node::shared_ptr node, bool overrideStaticTimeNow = true, bool allowFallbackToSystemClock = true, milliseconds initialBlockWaitingForClockMsg = 50ms);
+    Time now()
+    void register_clock_message_received_handler(std::function ...)
+    void register_time_about_to_reverse_handler(std::function ...)
+    void register_time_about_to_jump_backwards_handler(std::function ...)
+    ...
+```
 
 ## References
 

--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -22,15 +22,15 @@ Original Author: {{ page.author }}
 ## Background
 
 Many robotics algorithms inherently rely on timing as well as synchronization.
-To this end we require that nodes running in the ROS network have a synchronized system clock such that they can accurately report timestamps for events.
+To this end we require that nodes running in the ROS network have a synchronized clock such that they can accurately report timestamps for events.
 
-There are however several use cases where being able to control the progress of the system is important.
+There are, however, several other use cases where being able to control the progress of the system is important. We review those next.
 
 ## Use cases requiring time abstraction
 
 When playing back logged data it is often very valuable to support accelerated, slowed, or stepped control over the progress of time.
 This control can allow you to get to a specific time and pause the system so that you can debug it in depth.
-It is possible to do this with a log of the sensor data, however if the sensor data is out of synchronization with the rest of the system it will break many algorithms.
+It is possible to do this with a log of the sensor data. However, if the sensor data is out of synchronization with the rest of the system, it will break many algorithms.
 
 Another important use case for using an abstracted time source is when you are running logged data against a simulated robot instead of a real robot.
 Depending on the simulation characteristics, the simulator may be able to run much faster than real time or it may need to run much slower.
@@ -39,20 +39,22 @@ Slower than real time simulation is necessary for complicated systems where accu
 Often the simulation is the limiting factor for the system and as such the simulator can be a time source for faster or slower playback.
 Additionally if the simulation is paused the system can also pause using the same mechanism.
 
+A third situation arises with hardware that doesn't have a system clock chip available. Nodes running there need to be notified of the current time so that they can utilize that information to time-stamp their output. We will assume that nodes running on this type of hardware have accurate timers available.
+
 ### Challenges in using abstracted time
 
 There are many algorithms for synchronization and they can typically achieve accuracies which are better than the latency of the network communications between devices on the network.
 However, these algorithms take advantage of assumptions about the constant and continuous nature of time.
 
-An important aspect of using an abstracted time is to be able to manipulate time.
+Again, this is not the primary intent of synchronizing time between ROS nodes. We need to ensure the ability to manipulate time.
 In some cases, speeding up, slowing down, or pausing time entirely is important for debugging.
-
-The ability to support pausing time requires that we not assume that the time values are always increasing.
+And the ability to support pausing time requires that we not assume that the time values are always increasing.
 
 When communicating the changes in time propagation, the latencies in the communication network becomes a challenge.
 Any change in the time abstraction must be communicated to the other nodes in the graph, but will be subject to normal network communication latency.
 This inaccuracy is proportional to the latency of communications and also proportional to the increase in the real time factor.
 If very accurate timestamping is required when using the time abstraction, it can be achieved by slowing down the real time factor such that the communication latency is comparatively small.
+Of course we recommend using synchronized system clock sources for live work on nodes spread across multiple devices.
 
 The final challenge is that the time abstraction must be able to jump backwards in time, a feature that is useful for log file playback.
 This behavior is similar to a system clock after a negative date change, and requires developers using the time abstraction to make sure their algorithm can deal with the discontinuity.
@@ -60,64 +62,66 @@ Appropriate APIs must be provided for to the developer API to enable notificatio
 
 ### Time Abstractions
 
-There will be at least three versions of these abstractions with the following types, `SystemTime`, `SteadyTime` and `ROSTime`.
-These choices are designed to parallel the [`std::chrono`][] [`system_clock`][] and [`steady_clock`][].
+There will be at least three versions of these abstractions with the following types, `ROSTime`, `SystemTime`, and `SteadyTime`.
+The latter two choices are designed to parallel the [`std::chrono`][] [`system_clock`][] and [`steady_clock`][].
 It is expected that the default choice of time will be to use the `ROSTime` source, however the parallel implementations supporting `steady_clock` and `system_clock` will be maintained for use cases where the alternate time source is required.
-
-#### System Time
-
-For convenience in these cases we will also provide the same API as above, but use the name `SystemTime`.
-
-`SystemTime` will be directly tied to the system clock.
 
 #### Steady Time
 
-Example use cases for this include hardware drivers which are interacting with peripherals with hardware timeouts.
+Steady Time implies a realtime incrementing source. There is no modern hardware that does not support this option. Steady Time typically begins at system bootup and measures increments using hardware frequency counters.
+
+Example use cases for this include hardware drivers which are interacting with peripherals with hardware timeouts and systems lacking a realtime clock chip.
 
 In nodes which require the use of `SteadyTime` or `SystemTime` for interacting with hardware or other peripherals it is expected that they do a best effort to isolate any `SystemTime` or `SteadyTime` information inside their implementation and translate external interfaces to use the ROS time abstraction when communicating over the ROS network.
 
+#### System Time
+
+System Time pulls the current time from the system clock chip. It provides benefit over Steady Time when all nodes in the system have synchronized system time available.
+
+For convenience in these cases we will also provide the same API as above, but use the name `SystemTime`.
+
+We expect a System Time publisher to throw an error if the system clock resource is not available.
+
+
 #### ROS Time
 
-The `ROSTime` will report the same as `SystemTime` when an ROS Time Source is not active.
-When the ROS time source is active `ROSTime` will return the latest value reported by the Time Source.
+ROS Time derives the current time from the most-recently received clock broadcast message published on the `/clock` topic.
 
-### ROS Time Sources
+When the ROS time source is active `ROSTime` will return the latest value reported by the Time Source plus the elapsed time since that report multiplied by the real time factor.
+
+The ROS Time broadcast (clock message) needs to include this information:
+- The current time in nanoseconds
+- The current time multiplier (also called "factor", typically one, but could zero for paused or negative for going backwards)
+- If possible, the system clock time (in nanoseconds) when the message was published
+
+### ROS Time Message Sources
+
+- An included (where?) Steady Clock Publisher.
+- An included (where?) System Clock Publisher.
+- An included (where?) Gazebo Plugin.
 
 #### Default Time Source
 
-To implement the time abstraction the following approach will be used.
+Users can call `Node::now()` for the current time.
+With the assumption of a single Node instance per process, you can also get the current time from a static method: `Time::now()`.
+Nodes will automatically subscribe for the `/clock` message unless it is programmatically disabled. (Do we need to disable it? We can simply "not publish" to use the system clock.)
+If a publisher exists for the `/clock` topic, it will override the system time when using the ROS time abstraction.
+The `ROSTime` and the `now()` methods will fall back to `SystemTime` (and then `SteadyTime`) when an ROS Time Source is not active (aka, it has been disabled purposely or hasn't received a clock broadcast).
 
-The time abstraction can be published by one source on the `/clock` topic.
-The topic will contain the most up to date time for the ROS system.
-If a publisher exists for the topic, it will override the system time when using the ROS time abstraction.
-If `/clock` is being published, calls to the ROS time abstraction will return the latest time received from the `/clock` topic.
-If time has not been set it will return zero if nothing has been received.
-A time value of zero should be considered an error meaning that time is uninitialized.
-
-If the time on the clock jumps backwards, a callback handler will be invoked and be required to complete before any calls to the ROS time abstraction report the new time.
-Calls that come in before that must block.
+Users can also add callbacks to `Node::time_reversing` and `Node::time_jumping_back`.
 The developer has the opportunity to register callbacks with the handler to clear any state from their system if necessary before time will be in the past.
+If the time on the clock jumps backwards, a callback handler will be invoked and be required to complete before any calls to the ROS time abstraction report the new time.
 
-The frequency of publishing the `/clock` as well as the granularity are not specified as they are application specific.
-
-##### No Advanced Estimating Clock
-
-There are more advanced techniques which could be included to attempt to estimate the propagation properties and extrapolate between time ticks.
-However all of these techniques will require making assumptions about the future behavior of the time abstraction.
-And in the case that playback or simulation is instantaneously paused, it will break any of these assumptions.
-There are techniques which would allow potential interpolation, however to make these possible it would require providing guarantees about the continuity of time into the future.
-For more accuracy the progress of time can be slowed, or the frequency of publishing can be increased.
-Tuning the parameters for the `/clock` topic lets you trade off time for computational effort and/or bandwidth.
+The frequency of publishing the `/clock` as well as the granularity are not specified as they are application specific. Assuming they latch one message, they shouldn't need to publish more often than the multiplier changes. If the realtime multiplier cannot be computed, the message will need to be published very frequently. 
 
 #### Custom Time Source
 
-It is possible that the user may have access to an out of band time source which can provide better performance than the default source the `/clock` topic.
+It is possible that the user may have access to an out-of-band-time source which can provide better performance than the default source the `/clock` topic.
 It might be possible that for their use case a more advanced algorithm would be needed to propagate the simulated time with adequate precision or latency with restricted bandwidth or connectivity.
 The user will be able to switch out the time source for either each instance of their Time object as well as have the ability to override the default for the process.
+This can be acheived in C++ using the template on the Time object. The RCL package also contains a method to disable `ROSTime`.
 
-It is possible to use an external time source such as GPS in as a ROSTime source, but it is recommended to integrate a time source like that using standard ntp integrations with the system clock since that is already an established mechanism and will not need to deal with more complicated changes such as time jumps.
-
-## Implementation
+It is possible to use an external time source such as GPS as a ROSTime source. When writing this publisher, ensure that you handle jumps in time (both forward and back) and set the realtime multipleir correctly in those situations.
 
 The `SystemTime`, `SteadyTime`, and `ROSTime` API's will be provided by each client library in an idiomatic way, but they may share a common implementation, e.g. provided by `rcl`.
 However, if a client library chooses to not use the shared implementation then it must implement the functionality itself.
@@ -126,9 +130,9 @@ However, if a client library chooses to not use the shared implementation then i
 
 In each implementation will provide `Time`, `Duration`, and `Rate` datatypes, for all three time source abstraction..
 The `Duration` will support a `sleep_for` function as well as a `sleep_until` method.
-The implementation will also provide a `Timer` object which will provide periodic callback functionality for all the abstractions.
+The implementation will also provide a `Timer` object which will provide periodic callback functionality for all the abstractions. It will be microsecond-accurate.
 
-### RCL implementation
+#### RCL implementation
 
 In `rcl` there will be datatypes and methods to implement each of the three time abstractions for each of the core datatypes.
 However at the `rcl` level the implementation will be incomplete as it will not have a threading model and will rely on the higher level implementation to provide any threading functionality such as is required by sleep methods.
@@ -139,6 +143,15 @@ The underlying datatypes will also provide ways to register notifications, howev
 <div class="alert alert-warning" markdown="1">
   <b>TODO:</b> Enumerate the <code>rcl</code> datastructures and methods here.
 </div>
+
+## Work Needing To Be Done (Apr 2017)
+
+- Decide where and when to autosubscribe to the `/clock` message. Built in to Node? A Node addon or service? Part of the first call to `rcl_node_init`?
+- Decide how to deal with multiple nodes in a single process that all update the one static time (or decide to ditch the static time methods).
+- Decide where to put the out-of-the-box clock publishers.
+- Ensure that there is no reason we can't enable `ROSTime` (with fallbacks) by default.
+- Change the RCL time implementation to call a method on the time source to return the current time (rather than using a field). This is necessary to compute the current time from the realtime factor. Fix the `rcl_get_ros_time` method to use the newly-added current time method.
+- Add an `rcl_time_source_t` (to the RCL project) for `ROSTime`.
 
 ## References
 


### PR DESCRIPTION
This pull request modifies the ROS2 time design to include a clock message with a realtime factor. It also further defines "ROS time". At the bottom of the document are some open questions. At ASI we presently uses our own time source. I find this painful; I don't want to have to modify each of the standard nodes to include this. I have some time that I can address this issue in the ROS2 core libraries. Hence, please make an effort to resolve the questions in the design soon so that I can put in pull requests to rcl and rclcpp that everyone is happy with. Tagging @tfoote @wjwwood @clalancette and @mikaelarguedas .