### PR TITLE
remap char and byte to int8_t and uint8_t

### DIFF
--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -54,8 +54,6 @@ Each of these can optionally be a dynamically or statically sized array.
 The following primitive types are defined:
 
 - `bool`
-- `byte`
-- `char`
 - `float32`, `float64`
 - `int8`, `uint8`
 - `int16`, `uint16`
@@ -71,9 +69,12 @@ The following primitive types are defined:
   <b>TODO:</b> <code>string</code> does not specify any encoding yet and the transport is agnostic to it, this means commonly it can only contain ASCII but all endpoints can also "agree" on using a specific encoding
 </div>
 
-<div class="alert alert-warning" markdown="1">
-  <b>TODO:</b> consider removing <code>byte</code>, <code>char</code> after specifying the mapping to C++ and Python
-</div>
+#### Deprecated field types
+
+The following primitive types are deprecated:
+
+- `byte` remapped to uint8_t
+- `char` remapped to int8_t
 
 #### Non-primitive field types
 
@@ -185,14 +186,6 @@ Depending on the type the following values are valid:
 
   - `true`, `1`
   - `false`, `0`
-
-- `byte`:
-
-  - an unsigned integer value in the following interval `[0, 255]`
-
-- `char`:
-
-  - an integer value in the following interval `[-128, 127]`
 
 - `float32` and `float64`:
 

--- a/articles/111_mapping_dds_types.md
+++ b/articles/111_mapping_dds_types.md
@@ -29,7 +29,7 @@ This article specifies the mapping between ROS interface types defined in the [i
 | -------- | ------------------ |
 | bool     | boolean            |
 | byte     | octet              |
-| char     | char               |
+| char     | octet              |
 | float32  | float              |
 | float64  | double             |
 | int8     | octet              |

--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -68,7 +68,7 @@ For each additional functionality it can be decided to include it from the first
 | -------- | ----------- |
 | bool     | bool        |
 | byte     | uint8_t     |
-| char     | char        |
+| char     | int8_t      |
 | float32  | float       |
 | float64  | double      |
 | int8     | int8_t      |

--- a/articles/114_generated_interfaces_python.md
+++ b/articles/114_generated_interfaces_python.md
@@ -54,8 +54,8 @@ The Python module `<package_name>.msg` / `<package_name>.srv` exports all messag
 | ROS type | Python type                  |
 | -------- | ---------------------------- |
 | bool     | builtins.bool                |
-| byte     | builtins.bytes with length 1 |
-| char     | builtins.str with length 1   |
+| byte     | builtins.int                 |
+| char     | builtins.int                 |
 | float32  | builtins.float               |
 | float64  | builtins.float               |
 | int8     | builtins.int                 |


### PR DESCRIPTION
This is a draft of what deprecating char and byte would look like.

What could be done on top: On the python side we could relax the constraint by allowing users to pass `builtin.bytes of length 1` and make the conversion in the setter functions

Connects to ros2/rosidl#190