### PR TITLE
Fix links which are wrong adress or typo

### DIFF
--- a/articles/100_ament.md
+++ b/articles/100_ament.md
@@ -129,7 +129,7 @@ ament provides an option to use symbolic links instead (if the platform supports
 This enables the developer to change the resources in the source space and skipping the installation step in many situations.
 
 For CMake packages this is achieved by optionally overriding the CMake `install()` function.
-For Python packages the [development mode](http://pythonhosted.org//setuptools/setuptools.html#development-mode) is used to install the package.
+For Python packages the [development mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode) is used to install the package.
 The symlinked install is an optional feature and must be enabled explicitly by the developer using the command line option `--symlink-install`.
 
 ### ament linters

--- a/articles/changes.md
+++ b/articles/changes.md
@@ -183,7 +183,7 @@ In ROS 2 a unified approach is being used.
 It is similar to dynamic reconfigure and a node named "global parameter server" (⏳) will accept requests to set values unconditionally.
 In ROS 1 all this information needs to be polled for changes in ROS 2 changes will be published to notify other entities.
 
-For more information please see the [parameter design](http://design.ros2.org/articles/ros_parameters.html.html) article.
+For more information please see the [parameter design](http://design.ros2.org/articles/ros_parameters.html) article.
 
 #### Actions (⏳)
 


### PR DESCRIPTION
This PR fixes links which are wrong adress or typo.

- Wrong address: `development mode` on https://github.com/ros2/design/blob/gh-pages/articles/100_ament.md
- Typo: `parameter design` on https://github.com/ros2/design/blob/gh-pages/articles/changes.md