### PR TITLE
updating test_local_deplpy to use update jekyll syntax

### DIFF
--- a/test_local_deploy.sh
+++ b/test_local_deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run --rm -v `pwd`:/srv/jekyll -i -t -p 127.0.0.1:4000:4000 jekyll/jekyll:pages
+docker run --rm -v `pwd`:/srv/jekyll -i -t -p 127.0.0.1:4000:4000 jekyll/jekyll:pages jekyll serve --watch


### PR DESCRIPTION
Really I think the default command upstream changed.

Small fix for testing locally isolated from #144 