### PR TITLE
lifecycle: change noun to verb for 'deactivate'

### DIFF
--- a/articles/node_lifecycle.md
+++ b/articles/node_lifecycle.md
@@ -59,7 +59,7 @@ There are 7 transitions exposed to a supervisory process, they are:
 - `configure`
 - `cleanup`
 - `activate`
-- `deactive`
+- `deactivate`
 - `shutdown`
 - `destroy`
 


### PR DESCRIPTION
As per subject.

Reading the rest of the article I'm pretty sure the transition is actually named `deactivate`, not `deactive` (which could be a state name).
