### PR TITLE
Clarify the language around zero initialization.

### DIFF
--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -103,6 +103,8 @@ All other constants are declared as `static const` members in the struct and the
 
 ### Constructors
 
+In the following discussion, "member" refers to the class member in the C++ class while "field" refers to the field definition in the IDL file.
+
 The *default constructor* initializes all members with their default value; if a field doesn't have a default value, then the member is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization).
 In some cases this may not be desirable, since these fields will often be immediately overwritten with user-provided values.
 Therefore, the constructor takes an optional directive of type `rosidl_generator_cpp::MessageInitialization` to control how initialization is done:

--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -103,17 +103,17 @@ All other constants are declared as `static const` members in the struct and the
 
 ### Constructors
 
-The *default constructor* initializes all members with their default value; if a field doesn't have a default value, then the field is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization).
+The *default constructor* initializes all members with their default value; if a field doesn't have a default value, then the member is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization).
 In some cases this may not be desirable, since these fields will often be immediately overwritten with user-provided values.
 Therefore, the constructor takes an optional directive of type `rosidl_generator_cpp::MessageInitialization` to control how initialization is done:
 
-- `MessageInitialization::ALL` - Initialize all members with their default value; if a field doesn't have a default value, then the field is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization)
+- `MessageInitialization::ALL` - Initialize all members with the field default value; if a field doesn't have a default value, then the member is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization)
   - The safest option, and also the default (used if not passing any argument to the constructor).
-- `MessageInitialization::SKIP` - Don't initialize any members; it is the user's responsibility to ensure that all fields get initialized with some value, otherwise undefined behavior may result
+- `MessageInitialization::SKIP` - Don't initialize any members; it is the user's responsibility to ensure that all members get initialized with some value, otherwise undefined behavior may result
   - Used for maximum performance if the user is setting all of the members themselves.
-- `MessageInitialization::ZERO` - Zero initialize all members; this differs from `MessageInitialization::ALL` in that all members will be [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization), and default values from the message definition will be ignored
+- `MessageInitialization::ZERO` - Zero initialize all members; all members will be [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization) ([dynamic size](interface_definition.html#arrays-with-dynamic-size) or [upper boundary](interface_definition.html#upper-boundaries) arrays will have zero elements), and default values from the message definition will be ignored
   - Used when the user doesn't want the overhead of initializing potentially complex or large default values, but still wants to ensure that all variables are properly initialized.
-- `MessageInitialization::DEFAULTS_ONLY` - Default initialize only fields that have default values assigned to individual members; all other fields will be left uninitialized
+- `MessageInitialization::DEFAULTS_ONLY` - Initialize only members that have field default values; all other members will be left uninitialized
   - Minimal initialization which ensures that existing code has correctly initialized members when a new field with a default value is added to the IDL later.
 
 Optionally the constructor can be invoked with an allocator.

--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -109,7 +109,7 @@ The *default constructor* initializes all members with their default value; if a
 In some cases this may not be desirable, since these fields will often be immediately overwritten with user-provided values.
 Therefore, the constructor takes an optional directive of type `rosidl_generator_cpp::MessageInitialization` to control how initialization is done:
 
-- `MessageInitialization::ALL` - Initialize all members with the field default value; if a field doesn't have a default value, then the member is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization)
+- `MessageInitialization::ALL` - Initialize each member with the field's default value; if a field doesn't have a default value, then the member is [value-initialized](http://en.cppreference.com/w/cpp/language/value_initialization)
   - The safest option, and also the default (used if not passing any argument to the constructor).
 - `MessageInitialization::SKIP` - Don't initialize any members; it is the user's responsibility to ensure that all members get initialized with some value, otherwise undefined behavior may result
   - Used for maximum performance if the user is setting all of the members themselves.


### PR DESCRIPTION
Once ros2/rosidl#254 goes in, this documentation update can be merged to clarify what happens with bounded or unbounded array types.

fixes #156

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>