### PR TITLE
Remove topic partitions

### DIFF
--- a/articles/140_topic_and_service_name_mapping.md
+++ b/articles/140_topic_and_service_name_mapping.md
@@ -202,7 +202,7 @@ The ROS topic and service name constraints allow more types of characters than t
 These must be substituted or otherwise removed during the process of converting the topic or service name to DDS concepts.
 Since ROS 2 topic and service names are expanded to fully qualified names, any balanced bracket (`{}`) substitutions and tildes (`~`) will have been expanded.
 Additionally any URL related syntax, e.g. the `rostopic://` prefix, will be removed once parsed.
-Previously forward slashes (`/`) were disallowed in DDS topic names, now the restriction has been lifted(see [issue](https://issues.omg.org/issues/lists/dds-rtf5#issue-42236) on omg.org) and therefore the ROS topic names are first prefixed with ROS Specific Namespace prefix (described below) are then mapped directly into DDS topic names.
+Previously forward slashes (`/`) were disallowed in DDS topic names, now the restriction has been lifted (see [issue](https://issues.omg.org/issues/lists/dds-rtf5#issue-42236) on omg.org) and therefore the ROS topic names are first prefixed with ROS Specific Namespace prefix (described below) are then mapped directly into DDS topic names.
 
 ### ROS Specific Namespace Prefix
 
@@ -253,9 +253,8 @@ Since all ROS topics are prefixed when being converted to DDS topic names, it ma
 For example, if an existing DDS program is publishing on the `image` topic (and is using the DDS equivalent to the ROS message type) then a ROS program could not subscribe to it because of the name mangling produced by the implicit ROS specific namespace.
 Therefore to allow ROS programs to interoperate with "native" DDS topic names the API should provide a way to skip the ROS specific prefixing.
 
-#### Communicating with Non-ROS Topics
 
-Now, There is an option in the API, a boolean `avoid_ros_namespace_convention` in the qos_profile which can be set to `false` to use ROS prefix and `true` to not using ROS namespace prefixing.
+There is an option in the API, a boolean `avoid_ros_namespace_convention` in the qos_profile which can be set to `false` to use ROS prefix and `true` to not using ROS namespace prefixing.
 
 For example:
 
@@ -264,7 +263,8 @@ For example:
 | `rostopic://image`    | `false`                            | `rt/image`  |
 | `rostopic://image`    | `true`                             | `image`     |
 
-Alternative(Idea):
+#### Alternative(Idea)
+
 Note that the alternative below is not part of the proposal, but only possible solutions to the issue of communicating with "native" DDS topics.
 Another option would be to have some markup in the scheme name, for example:
 
@@ -277,7 +277,7 @@ Another option would be to have some markup in the scheme name, for example:
 
 ## Compare and Contrast with ROS 1
 
-In order to support a mapping to a little more restrictive DDS topic name rules, these rules are in some ways more constraining than the rules for ROS 1.
+In order to support a mapping to the - slightly more - restrictive DDS topic name rules, these rules are in some ways more constraining than the rules for ROS 1.
 Other changes have been proposed for convenience or to remove a point of confusion that existed in ROS 1.
 In ROS 2, topic and service names differ from ROS 1 in that they:
 
@@ -359,10 +359,10 @@ You can read more about partitions in RTI's documentation:
 
 Trade-offs (in comparison to using the whole ROS name along with the namespaces):
 
-- Splitting the ROS name into "namespace" and "base name", and placing the complete namespace into a single partition seemed un-natural.
+- Splitting the ROS name into "namespace" and "base name", and placing the complete namespace into a field designed for another purpose seemed incorrect.
 - In general partitions are recommended to be used as a spare, but using partitions for all ROS names suggested otherwise.
-- Major concern was reported in this [issue](https://github.com/ros2/rmw_connext/issues/234), where having two topics with same base name, although different namespace and different ypes caused problem. For example: topicA is `/camera/data` of type `Image` and topicB is `/imu/data` of type `Imu`. The base names for both topicA and topicB is `data`, generated errors as described in the [issue](https://github.com/ros2/rmw_connext/issues/234).
-- Newer standards such as XRCE DDS might not have partitions at all.
+- Major concern was reported in this [issue](https://github.com/ros2/rmw_connext/issues/234), where having two topics with same base name, although different namespace and different types caused problem. For example: topicA is `/camera/data` of type `Image` and topicB is `/imu/data` of type `Imu`. The base names for both topicA and topicB is `data`, generated errors as described in the [issue](https://github.com/ros2/rmw_connext/issues/234).
+- Newer standards such as [DDS-XRCE](https://www.omg.org/spec/DDS-XRCE) might not have partitions at all.
 - Using the complete ROS name in the later strategy will cause a tighter length limit on base name because the DDS topic name would contain ROS prefix, namespace along with the base name which should not exceed DDS topic name limitation which is  256 characters.
 
 Rationale:

--- a/articles/140_topic_and_service_name_mapping.md
+++ b/articles/140_topic_and_service_name_mapping.md
@@ -211,7 +211,7 @@ For example, a plain topic called `/foo` would translate to a DDS topic `rt/foo`
 As another example, a topic called `/left/image_raw` would translate to a DDS topic `rt/left/image_raw`, which is the result of implicitly adding `rt` to the namespace of a ROS topic which is in the namespace `/left` and has a base name `image_raw`.
 
 For systems where Services are implemented with topics (like with OpenSplice), a different subsystem character can be used: `rq` for the request topic and `rr` for the response topic.
-On systems where the implementation is handled for us by DDS (like with Connext), we use `rs` as the common prefix.
+On systems where Services are handled explicitly implemented, we consider a separate prefix, e.g. `rs`.
 
 Here is a non-exhaustive list of prefixes:
 
@@ -242,10 +242,13 @@ Here are some examples of how a fully qualified ROS name would be broken down in
 
 The length of the DDS topic must not exceed 256 characters. Therefore the length of a ROS Topic, including the namespace hierarchy, the base name of the topic and any ros specific prefixes must not exceed 256 characters since this is mapped directly as DDS topic.
 
-The length of service name has tighter limits than the length of the ROS Topics.
-In underlying RMW-DDS implementation, because the way in which services are implemented vary for different DDS vendors, and hence imposes the limit on actual service names that can be used.
-For example, in RTI connext, the service names are suffixed with the GUID value of the DDS participant, and a content filtered topic(max length 256 characters) is created which is mapped from the suffixed service name.
-Therefore with rmw_connext implementation, service name cannot be greater than 185 characters including namespace hierarchy and any ros specific prefixes.
+#### Considerations for RTI Connext
+
+While testing our implementation with Connext, we encountered some additional limitations when it comes to the topic length.
+That is, for example the length of a service name has tighter limits than the length of the ROS Topics.
+The RTI Connext implementation for service names are suffixed with the GUID value of the DDS participant for the service response topic.
+Additionally, a content filtered topic (max length 256 characters) is created which is mapped from the suffixed service name.
+Therefore when linking against `rmw_connext_c` or `rmw_connext_cpp`, service names cannot be longer than 185 characters including the namespace hierarchy and any ros specific prefixes.
 
 ### Communicating with Non-ROS Topics
 


### PR DESCRIPTION
connects to ros2/ros2#476
Update design to specify the usage of the topic/service name directly without using the partitions.