### PR TITLE
Messages on /clock must be delivered in order

### DIFF
--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -109,7 +109,6 @@ If the time on the clock jumps backwards, a callback handler will be invoked and
 Calls that come in before that must block.
 The developer has the opportunity to register callbacks with the handler to clear any state from their system if necessary before time will be in the past.
 
-Messages published on `/clock` must be delivered in order.
 The frequency of publishing the `/clock` as well as the granularity are not specified as they are application specific.
 
 ##### No Advanced Estimating Clock By Default

--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -109,6 +109,7 @@ If the time on the clock jumps backwards, a callback handler will be invoked and
 Calls that come in before that must block.
 The developer has the opportunity to register callbacks with the handler to clear any state from their system if necessary before time will be in the past.
 
+Messages published on `/clock` must be delivered in order.
 The frequency of publishing the `/clock` as well as the granularity are not specified as they are application specific.
 
 ##### No Advanced Estimating Clock By Default

--- a/articles/qos.md
+++ b/articles/qos.md
@@ -103,6 +103,14 @@ However, this mechanism will not be added into the common ROS2 API so as to keep
 To honor the QoS settings of the system, developers can use the `rmw_qos_profile_system_default` QoS profile which delegates the responsibility of the QoS machinery to the underlying DDS vendor.
 This allows developers to deploy ROS2 applications and use DDS vendor tools to configure the QoS settings.
 
+## Integration with non DDS RMW Implementations
+
+There is no QoS setting that affects the order messages may be received.
+Instead an RMW implementation must implement the same behavior as DDS.
+Once a subscriber takes a message from the RMW implementation it must not be allowed to take an earlier message from the same publisher.
+If the connection is Reliable then newer messages should be kept in the History until all older messages are received.
+A best effort connection should drop an older message if it has already received a newer one.
+
 ## Open questions
 
 How should the integration of the QoS machinery with intraprocess communication be like.

--- a/articles/qos.md
+++ b/articles/qos.md
@@ -109,7 +109,7 @@ There is no QoS setting that affects the order messages may be received.
 Instead an RMW implementation must implement the same behavior as DDS.
 Once a subscriber takes a message from the RMW implementation it must not be allowed to take an earlier message from the same publisher.
 If the connection is Reliable then newer messages should be kept in the History until all older messages are received.
-A best effort connection should drop an older message if it has already received a newer one.
+A best effort connection should drop an older message if a subscriber has taken a newer one.
 
 ## Open questions
 


### PR DESCRIPTION
Add sentence saying messages published on `/clock` must be delivered in order. The design doc requires an API to call user callbacks when time jumps backwards. If messages are received out of order then state could be reset unnecessarily.