### PR TITLE
Add type mapping info to documents

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -197,9 +197,42 @@ When specified `T` is either one of the types above or an IDL struct.
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.
 
-| IDL type                     | C type                            | C++ type       | Python type |
-| ---------------------------- | --------------------------------- | -------------- | ----------- |
-| octet[N]                     |                                   |                | bytes       |
-| sequence<octet>              |                                   |                | bytes       |
-| sequence<octet, N>           |                                   |                | bytes       |
-| array of string              | struct {size\_t, T * }, size\_t N |                |             |
+| IDL type                     | C type                            | C++ type       | Python type                      |
+| ---------------------------- | --------------------------------- | -------------- | -------------------------------- |
+| octet[N]                     |                                   |                | bytes                            |
+| sequence<octet>              |                                   |                | bytes                            |
+| sequence<octet, N>           |                                   |                | bytes                            |
+| array of string              | struct {size\_t, T * }, size\_t N |                |                                  |
+| int8[N]                      |                                   |                | numpy.array(dtype=numpy.int8)    |
+| sequence<int8>               |                                   |                | numpy.array(dtype=numpy.int8)    |
+| sequence<int8, N>            |                                   |                | numpy.array(dtype=numpy.int8)    |
+| uint8[N]                     |                                   |                | numpy.array(dtype=numpy.uint8)   |
+| sequence<uint8>              |                                   |                | numpy.array(dtype=numpy.uint8)   |
+| sequence<uint8, N>           |                                   |                | numpy.array(dtype=numpy.uint8)   |
+| int16[N]                     |                                   |                | numpy.array(dtype=numpy.int16)   |
+| sequence<int16>              |                                   |                | numpy.array(dtype=numpy.int16)   |
+| sequence<int16, N>           |                                   |                | numpy.array(dtype=numpy.int16)   |
+| uint16[N]                    |                                   |                | numpy.array(dtype=numpy.uint16)  |
+| sequence<uint16>             |                                   |                | numpy.array(dtype=numpy.uint16)  |
+| sequence<uint16, N>          |                                   |                | numpy.array(dtype=numpy.uint16)  |
+| int32[N]                     |                                   |                | numpy.array(dtype=numpy.int32)   |
+| sequence<int32>              |                                   |                | numpy.array(dtype=numpy.int32)   |
+| sequence<int32, N>           |                                   |                | numpy.array(dtype=numpy.int32)   |
+| uint32[N]                    |                                   |                | numpy.array(dtype=numpy.uint32)  |
+| sequence<uint32>             |                                   |                | numpy.array(dtype=numpy.uint32)  |
+| sequence<uint32, N>          |                                   |                | numpy.array(dtype=numpy.uint32)  |
+| int64[N]                     |                                   |                | numpy.array(dtype=numpy.int64)   |
+| sequence<int64>              |                                   |                | numpy.array(dtype=numpy.int64)   |
+| sequence<int64, N>           |                                   |                | numpy.array(dtype=numpy.int64)   |
+| uint64[N]                    |                                   |                | numpy.array(dtype=numpy.uint64)  |
+| sequence<uint64>             |                                   |                | numpy.array(dtype=numpy.uint64)  |
+| sequence<uint64, N>          |                                   |                | numpy.array(dtype=numpy.uint64)  |
+| float[N]                     |                                   |                | numpy.array(dtype=numpy.float\_) |
+| sequence<float>              |                                   |                | numpy.array(dtype=numpy.float\_) |
+| sequence<float, N>           |                                   |                | numpy.array(dtype=numpy.float\_) |
+| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
+| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
+| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
+| long double[N]               |                                   |                | numpy.array(dtype=numpy.float64) |
+| sequence<long double>        |                                   |                | numpy.array(dtype=numpy.float64) |
+| sequence<long double, N>     |                                   |                | numpy.array(dtype=numpy.float64) |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -55,9 +55,9 @@ ROS 2 supports a subset of the [OMG IDL 4.2 specification](https://www.omg.org/s
 
 #### 7.4.1.4.4.2.3 Char Type
 
-| IDL type | Value range                   |
-| -------- | ----------------------------- |
-| char     | A 8-bit single-byte character |
+| IDL type | Value range                                                                            |
+| -------- | -------------------------------------------------------------------------------------- |
+| char     | A 8-bit single-byte character with a numerical value between 0 and 255 (see 7.2.6.2.1) |
 
 The type can store a single-byte character from any byte-oriented code set, or
 when used in an array, encode a multi-byte character from a multi-byte code set.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -168,7 +168,7 @@ The next table defines how IDL types are mapped to the following programming lan
 | char        | signed char | char                           | str with length 1    |
 | wchar       | char16\_t   | char16\_t                      | str with length 1    |
 | bool        | \_Bool      | bool                           | bool                 |
-| octet       | uint8\_t    | std::byte[<sub>1</sub>](#byte) | bytes with length 1  |
+| octet       | uint8\_t    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |
 | int8        | int8\_t     | int8\_t                        | int                  |
 | uint8       | uint8\_t    | uint8\_t                       | int                  |
 | int16       | int16\_t    | int16\_t                       | int                  |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -182,15 +182,15 @@ The next table defines how IDL types are mapped to the following programming lan
 
 The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
 
-| IDL type       | C type                 | C++ type            | Python type |
-| -------------- | ---------------------- | ------------------- | ----------- |
-| T[N]           | T[N]                   | std::array<T, N>    | list        |
-| sequence<T>    | struct {size\_t, T * } | std::vector<T>      | list        |
-| sequence<T, N> | struct {size\_t, T * } | custom\_class<T, N> | list        |
-| string         | char *                 | std::string         | str         |
-| string<N>      | char *                 | std::string         | str         |
-| wstring        | char16\_t *            | std::u16string      | str         |
-| wstring<N>     | char16\_t *            | std::u16string      | str         |
+| IDL type       | C type                 | C++ type          | Python type |
+| -------------- | ---------------------- | ----------------- | ----------- |
+| T[N]           | T[N]                   | std::array<T, N>  | list        |
+| sequence<T>    | struct {size\_t, T * } | std::vector<T>    | list        |
+| sequence<T, N> | struct {size\_t, T * } | std::vector<T, N> | list        |
+| string         | char *                 | std::string       | str         |
+| string<N>      | char *                 | std::string       | str         |
+| wstring        | char16\_t *            | std::u16string    | str         |
+| wstring<N>     | char16\_t *            | std::u16string    | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -188,9 +188,11 @@ If a cell is blank then the default mapping is used.
 
 | IDL type                     | C type                 | C++ type       | Python type |
 | ---------------------------- | ---------------------- | -------------- | ----------- |
+| octet[N]                     |                        |                | bytes       |
+| sequence<octet>              |                        |                | bytes       |
+| sequence<octet, N>           |                        |                | bytes       |
 | array of string              | rcutils\_string\_array |                |             |
 | unbounded sequence of string | rcutils\_string\_array |                |             |
 | bounded sequence of string   | rcutils\_string\_array |                |             |
-| array of octet               |                        |                | bytes       |
 | array of char                | char *                 | std::string    | str         |
 | array of wchar               | char16\_t *            | std::u16string | str         |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -181,16 +181,18 @@ The next table defines how IDL types are mapped to the following programming lan
 1. <a name="byte"></a>If std::byte is not available then uint8\_t is used instead.
 
 The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
+When specified `T` is either one of the types above or an IDL struct.
+`N` is the upper limit of a bounded type.
 
-| IDL type       | C type                 | C++ type          | Python type |
-| -------------- | ---------------------- | ----------------- | ----------- |
-| T[N]           | T[N]                   | std::array<T, N>  | list        |
-| sequence<T>    | struct {size\_t, T * } | std::vector<T>    | list        |
-| sequence<T, N> | struct {size\_t, T * } | std::vector<T, N> | list        |
-| string         | char *                 | std::string       | str         |
-| string<N>      | char *                 | std::string       | str         |
-| wstring        | char16\_t *            | std::u16string    | str         |
-| wstring<N>     | char16\_t *            | std::u16string    | str         |
+| IDL type       | C type                            | C++ type          | Python type |
+| -------------- | --------------------------------- | ----------------- | ----------- |
+| T[N]           | T[N]                              | std::array<T, N>  | list        |
+| sequence<T>    | struct {size\_t, T * }            | std::vector<T>    | list        |
+| sequence<T, N> | struct {size\_t, T * }, size\_t N | std::vector<T, N> | list        |
+| string         | char *                            | std::string       | str         |
+| string<N>      | char *                            | std::string       | str         |
+| wstring        | char16\_t *                       | std::u16string    | str         |
+| wstring<N>     | char16\_t *                       | std::u16string    | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -160,23 +160,25 @@ The next table defines how IDL types are mapped to the following programming lan
 * C++11 (or higher)
 * Python 3 (or higher)
 
-| IDL type    | C type      | C++ type    | Python type          |
-| --------    | ----------- | ----------- | -------------------- |
-| float       | float       | float       | float                |
-| double      | double      | double      | float                |
-| long double | long double | long double | float                |
-| char        | signed char | char        | str with length 1    |
-| wchar       | char16\_t   | char16\_t   | str with length 1    |
-| bool        | \_Bool      | bool        | bool                 |
-| octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
-| int8        | int8\_t     | int8\_t     | int                  |
-| uint8       | uint8\_t    | uint8\_t    | int                  |
-| int16       | int16\_t    | int16\_t    | int                  |
-| uint16      | uint16\_t   | uint16\_t   | int                  |
-| int32       | int32\_t    | int32\_t    | int                  |
-| uint32      | uint32\_t   | uint32\_t   | int                  |
-| int64       | int64\_t    | int64\_t    | int                  |
-| uint64      | uint64\_t   | uint64\_t   | int                  |
+| IDL type    | C type      | C++ type                       | Python type          |
+| --------    | ----------- | ------------------------------ | -------------------- |
+| float       | float       | float                          | float                |
+| double      | double      | double                         | float                |
+| long double | long double | long double                    | float                |
+| char        | signed char | char                           | str with length 1    |
+| wchar       | char16\_t   | char16\_t                      | str with length 1    |
+| bool        | \_Bool      | bool                           | bool                 |
+| octet       | uint8\_t    | std::byte[<sub>1</sub>](#byte) | bytes with length 1  |
+| int8        | int8\_t     | int8\_t                        | int                  |
+| uint8       | uint8\_t    | uint8\_t                       | int                  |
+| int16       | int16\_t    | int16\_t                       | int                  |
+| uint16      | uint16\_t   | uint16\_t                      | int                  |
+| int32       | int32\_t    | int32\_t                       | int                  |
+| uint32      | uint32\_t   | uint32\_t                      | int                  |
+| int64       | int64\_t    | int64\_t                       | int                  |
+| uint64      | uint64\_t   | uint64\_t                      | int                  |
+
+1. <a name="byte"></a>If std::byte is not available then uint8\_t is used instead.
 
 The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -194,5 +194,3 @@ If a cell is blank then the default mapping is used.
 | array of string              | rcutils\_string\_array |                |             |
 | unbounded sequence of string | rcutils\_string\_array |                |             |
 | bounded sequence of string   | rcutils\_string\_array |                |             |
-| array of char                | char *                 | std::string    | str         |
-| array of wchar               | char16\_t *            | std::u16string | str         |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -199,10 +199,18 @@ If a cell is blank then the default mapping is used.
 
 | IDL type                     | C type                            | C++ type       | Python type                      |
 | ---------------------------- | --------------------------------- | -------------- | -------------------------------- |
+| float[N]                     |                                   |                | numpy.array(dtype=numpy.float\_) |
+| sequence<float>              |                                   |                | numpy.array(dtype=numpy.float\_) |
+| sequence<float, N>           |                                   |                | numpy.array(dtype=numpy.float\_) |
+| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
+| sequence<double>             |                                   |                | numpy.array(dtype=numpy.float32) |
+| sequence<double, N>          |                                   |                | numpy.array(dtype=numpy.float32) |
+| long double[N]               |                                   |                | numpy.array(dtype=numpy.float64) |
+| sequence<long double>        |                                   |                | numpy.array(dtype=numpy.float64) |
+| sequence<long double, N>     |                                   |                | numpy.array(dtype=numpy.float64) |
 | octet[N]                     |                                   |                | bytes                            |
 | sequence<octet>              |                                   |                | bytes                            |
 | sequence<octet, N>           |                                   |                | bytes                            |
-| array of string              | struct {size\_t, T * }, size\_t N |                |                                  |
 | int8[N]                      |                                   |                | numpy.array(dtype=numpy.int8)    |
 | sequence<int8>               |                                   |                | numpy.array(dtype=numpy.int8)    |
 | sequence<int8, N>            |                                   |                | numpy.array(dtype=numpy.int8)    |
@@ -227,12 +235,4 @@ If a cell is blank then the default mapping is used.
 | uint64[N]                    |                                   |                | numpy.array(dtype=numpy.uint64)  |
 | sequence<uint64>             |                                   |                | numpy.array(dtype=numpy.uint64)  |
 | sequence<uint64, N>          |                                   |                | numpy.array(dtype=numpy.uint64)  |
-| float[N]                     |                                   |                | numpy.array(dtype=numpy.float\_) |
-| sequence<float>              |                                   |                | numpy.array(dtype=numpy.float\_) |
-| sequence<float, N>           |                                   |                | numpy.array(dtype=numpy.float\_) |
-| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
-| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
-| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
-| long double[N]               |                                   |                | numpy.array(dtype=numpy.float64) |
-| sequence<long double>        |                                   |                | numpy.array(dtype=numpy.float64) |
-| sequence<long double, N>     |                                   |                | numpy.array(dtype=numpy.float64) |
+| array of string              | struct {size\_t, T * }, size\_t N |                |                                  |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -166,7 +166,7 @@ The next table defines how IDL types are mapped to the following programming lan
 | float       | float            | float                          | float                |
 | double      | double           | double                         | float                |
 | long double | long double      | long double[<sup>2</sup>](#ld) | float                |
-| char        | signed char      | char                           | str with length 1    |
+| char        | unsigned char    | unsigned char                  | str with length 1    |
 | wchar       | char16\_t        | char16\_t                      | str with length 1    |
 | bool        | \_Bool           | bool                           | bool                 |
 | octet       | unsigned char    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -149,8 +149,9 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 Generated code for messages is only guaranteed to enforce constraints when a message is published.
 For example, there might not be an error when a field constrained to be a fixed size array is assigned an array with the wrong size.
-In the future constraints might be checked when a field is set.
-Users of generated message code should assume constraints are enforced when fields are set or modified.
+This could be inconsistent accross client library implementations depending on language features and performance cost.
+In the future any client library may add additional constraint checking when a field is set or modified.
+Users of generated message code should assume constraints could be enforced at any time to be compatible with such a change.
 
 ### Type Mapping
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -154,8 +154,8 @@ IDL types mapped to different types in different languages.
 | --------    | ----------- | ----------- | -------------------- |
 | bool        | \_Bool      | bool        | bool                 |
 | octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
-| char        | char16\_t   | char16\_t   | str with length 1    |
-| wchar       | signed char | char        | str with length 1    |
+| char        | signed char | char        | str with length 1    |
+| wchar       | char16\_t   | char16\_t   | str with length 1    |
 | float       | float       | float       | float                |
 | double      | double      | double      | float                |
 | long double | long double | long double | float                |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -145,6 +145,13 @@ For now only a one-dimensional, fixed-size array is supported though.
   <b>TODO:</b> All of this too
 </div>
 
+### Constraint Checking
+
+Generated code for messages is guaranteed to enforce constraints only when a message is published.
+For example, there might not be an error when a field constrained to be a fixed size array is assigned an array with the wrong size.
+In the future constraints might be checked when a field is set.
+Users of generated message code should assume constraints are enforced when fields are set.
+
 ### Type Mapping
 
 The next table defines how IDL types are mapped to the following programming languages:

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -150,21 +150,21 @@ For now only a one-dimensional, fixed-size array is supported though.
 IDL types mapped to different types in different languages.
 
 
-| IDL type | C type    | C++ type    | Python type          |
-| -------- | --------- | ----------- | -------------------- |
-| bool     | \_Bool    | bool        | bool                 |
-| octet    | uint8\_t  | uint8\_t    | bytes with length 1  |
-| char     | char      | char        | str with length 1    |
-| float    | float     | float       | float                |
-| double   | double    | double      | float                |
-| int8     | int8\_t   | int8\_t     | int                  |
-| uint8    | uint8\_t  | uint8\_t    | int                  |
-| int16    | int16     | int16       | int                  |
-| uint16   | uint16    | uint16      | int                  |
-| int32    | int32     | int32       | int                  |
-| uint32   | uint32    | uint32      | int                  |
-| int64    | int64     | int64       | int                  |
-| uint64   | uint64\_t | uint64\_t   | int                  |
+| IDL type | C type      | C++ type    | Python type          |
+| -------- | ----------- | ----------- | -------------------- |
+| bool     | \_Bool      | bool        | bool                 |
+| octet    | uint8\_t    | uint8\_t    | bytes with length 1  |
+| char     | signed char | char        | str with length 1    |
+| float    | float       | float       | float                |
+| double   | double      | double      | float                |
+| int8     | int8\_t     | int8\_t     | int                  |
+| uint8    | uint8\_t    | uint8\_t    | int                  |
+| int16    | int16       | int16       | int                  |
+| uint16   | uint16      | uint16      | int                  |
+| int32    | int32       | int32       | int                  |
+| uint32   | uint32      | uint32      | int                  |
+| int64    | int64       | int64       | int                  |
+| uint64   | uint64\_t   | uint64\_t   | int                  |
 
 Unless are the default mappings for array, sequence, and string types unless otherwise specified.
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -200,39 +200,9 @@ When specified `T` is either one of the types above or an IDL struct.
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.
 
-| IDL type                     | C type                            | C++ type       | Python type                                     |
-| ---------------------------- | --------------------------------- | -------------- | ----------------------------------------------- |
-| float[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float32) |
-| sequence<float>              |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
-| sequence<float, N>           |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
-| double[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float64) |
-| sequence<double>             |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
-| sequence<double, N>          |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
-| octet[N]                     |                                   |                | bytes                                           |
-| sequence<octet>              |                                   |                | bytes                                           |
-| sequence<octet, N>           |                                   |                | bytes                                           |
-| int8[N]                      |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int8)    |
-| sequence<int8>               |                                   |                | numpy.ndarray(dtype=numpy.int8)                 |
-| sequence<int8, N>            |                                   |                | numpy.ndarray(dtype=numpy.int8)                 |
-| uint8[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint8)   |
-| sequence<uint8>              |                                   |                | numpy.ndarray(dtype=numpy.uint8)                |
-| sequence<uint8, N>           |                                   |                | numpy.ndarray(dtype=numpy.uint8)                |
-| int16[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int16)   |
-| sequence<int16>              |                                   |                | numpy.ndarray(dtype=numpy.int16)                |
-| sequence<int16, N>           |                                   |                | numpy.ndarray(dtype=numpy.int16)                |
-| uint16[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint16)  |
-| sequence<uint16>             |                                   |                | numpy.ndarray(dtype=numpy.uint16)               |
-| sequence<uint16, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint16)               |
-| int32[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int32)   |
-| sequence<int32>              |                                   |                | numpy.ndarray(dtype=numpy.int32)                |
-| sequence<int32, N>           |                                   |                | numpy.ndarray(dtype=numpy.int32)                |
-| uint32[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint32)  |
-| sequence<uint32>             |                                   |                | numpy.ndarray(dtype=numpy.uint32)               |
-| sequence<uint32, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint32)               |
-| int64[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int64)   |
-| sequence<int64>              |                                   |                | numpy.ndarray(dtype=numpy.int64)                |
-| sequence<int64, N>           |                                   |                | numpy.ndarray(dtype=numpy.int64)                |
-| uint64[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint64)  |
-| sequence<uint64>             |                                   |                | numpy.ndarray(dtype=numpy.uint64)               |
-| sequence<uint64, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint64)               |
-| array of string              | struct {size\_t, T * }, size\_t N |                |                                                 |
+| IDL type                     |   | C type                            | C++ type       | Python type                                     |   |
+| ---------------------------- | - | --------------------------------- | -------------- | ----------------------------------------------- | - |
+| T[N]<br>sequence\<T><br>sequence<T, N> | for numeric types T:<br>float, double,<br>int8, uint8,<br>int16, uint16,<br>int32, uint32,<br>int64, uint64 | - | - | numpy.ndarray(shape=(N, ), dtype=numpy.DT) | where DT is determined by T:<br>float -> float32, double -> float64,<br>intX -> intX, uintX -> uintX, |
+| octet[N]                     |   | -                                 | -              | bytes                                           | |
+| sequence\<octet>              |   | -                                 | -              | bytes                                           | |
+| sequence<octet, N>           |   | -                                 | -              | bytes                                           | |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -149,7 +149,7 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 Generated code for messages is only guaranteed to enforce constraints when a message is published.
 For example, there might not be an error when a field constrained to be a fixed size array is assigned an array with the wrong size.
-This could be inconsistent accross client library implementations depending on language features and performance cost.
+This could be inconsistent across client library implementations depending on language features and performance cost.
 In the future any client library may add additional constraint checking when a field is set or modified.
 Users of generated message code should assume constraints could be enforced at any time to be compatible with such a change.
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -197,11 +197,9 @@ When specified `T` is either one of the types above or an IDL struct.
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.
 
-| IDL type                     | C type                 | C++ type       | Python type |
-| ---------------------------- | ---------------------- | -------------- | ----------- |
-| octet[N]                     |                        |                | bytes       |
-| sequence<octet>              |                        |                | bytes       |
-| sequence<octet, N>           |                        |                | bytes       |
-| array of string              | rcutils\_string\_array |                |             |
-| unbounded sequence of string | rcutils\_string\_array |                |             |
-| bounded sequence of string   | rcutils\_string\_array |                |             |
+| IDL type                     | C type                            | C++ type       | Python type |
+| ---------------------------- | --------------------------------- | -------------- | ----------- |
+| octet[N]                     |                                   |                | bytes       |
+| sequence<octet>              |                                   |                | bytes       |
+| sequence<octet, N>           |                                   |                | bytes       |
+| array of string              | struct {size\_t, T * }, size\_t N |                |             |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -144,3 +144,45 @@ For now only a one-dimensional, fixed-size array is supported though.
 <div class="alert alert-warning" markdown="1">
   <b>TODO:</b> All of this too
 </div>
+
+### Type Mapping
+
+IDL types mapped to different types in different languages.
+
+
+| IDL type | C type    | C++ type    | Python type          |
+| -------- | --------- | ----------- | -------------------- |
+| bool     | \_Bool    | bool        | bool                 |
+| octet    | uint8\_t  | uint8\_t    | bytes with length 1  |
+| char     | char      | char        | str with length 1    |
+| float    | float     | float       | float                |
+| double   | double    | double      | float                |
+| int8     | int8\_t   | int8\_t     | int                  |
+| uint8    | uint8\_t  | uint8\_t    | int                  |
+| int16    | int16     | int16       | int                  |
+| uint16   | uint16    | uint16      | int                  |
+| int32    | int32     | int32       | int                  |
+| uint32   | uint32    | uint32      | int                  |
+| int64    | int64     | int64       | int                  |
+| uint64   | uint64\_t | uint64\_t   | int                  |
+
+Unless are the default mappings for array, sequence, and string types unless otherwise specified.
+
+| IDL type                | C type                 | C++ type            | Python type |
+| ----------------------- | ---------------------- | ------------------- | ----------- |
+| array                   | T [FIXED\_SIZE]        | std::array<T, N>    | list        |
+| unbounded sequence      | struct {size\_t, T * } | std::vector<T>      | list        |
+| bounded sequence        | struct {size\_t, T * } | custom\_class<T, N> | list        |
+| string                  | char *                 | std::string         | str         |
+| bounded string          | char *                 | std::string         | str         |
+
+These array and sequence types have special mappings.
+If a cell is blank then the default mapping is used.
+
+| IDL type                     | C type                 | C++ type    | Python type |
+| ---------------------------- | ---------------------- | ----------- | ----------- |
+| array of string              | rcutils\_string\_array |             |             |
+| unbounded sequence of string | rcutils\_string\_array |             |             |
+| bounded sequence of string   | rcutils\_string\_array |             |             |
+| array of octet               |                        |             | bytes       |
+| array of char                | char *                 | std::string | str         |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -154,7 +154,8 @@ IDL types mapped to different types in different languages.
 | --------    | ----------- | ----------- | -------------------- |
 | bool        | \_Bool      | bool        | bool                 |
 | octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
-| char        | signed char | char        | str with length 1    |
+| char        | char16\_t   | char16\_t   | str with length 1    |
+| wchar       | signed char | char        | str with length 1    |
 | float       | float       | float       | float                |
 | double      | double      | double      | float                |
 | long double | long double | long double | float                |
@@ -176,14 +177,17 @@ Unless are the default mappings for array, sequence, and string types unless oth
 | bounded sequence        | struct {size\_t, T * } | custom\_class<T, N> | list        |
 | string                  | char *                 | std::string         | str         |
 | bounded string          | char *                 | std::string         | str         |
+| wstring                 | char16\_t *            | std::u16string      | str         |
+| bounded wstring         | char16\_t *            | std::u16string      | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.
 
-| IDL type                     | C type                 | C++ type    | Python type |
-| ---------------------------- | ---------------------- | ----------- | ----------- |
-| array of string              | rcutils\_string\_array |             |             |
-| unbounded sequence of string | rcutils\_string\_array |             |             |
-| bounded sequence of string   | rcutils\_string\_array |             |             |
-| array of octet               |                        |             | bytes       |
-| array of char                | char *                 | std::string | str         |
+| IDL type                     | C type                 | C++ type       | Python type |
+| ---------------------------- | ---------------------- | -------------- | ----------- |
+| array of string              | rcutils\_string\_array |                |             |
+| unbounded sequence of string | rcutils\_string\_array |                |             |
+| bounded sequence of string   | rcutils\_string\_array |                |             |
+| array of octet               |                        |                | bytes       |
+| array of char                | char *                 | std::string    | str         |
+| array of wchar               | char16\_t *            | std::u16string | str         |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -147,7 +147,7 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 ### Type Mapping
 
-The table defines how IDL types are mapped to the following programming languages:
+The next table defines how IDL types are mapped to the following programming languages:
 
 * C11 (or higher)
 * C++11 (or higher)
@@ -171,17 +171,17 @@ The table defines how IDL types are mapped to the following programming language
 | int64       | int64\_t    | int64\_t    | int                  |
 | uint64      | uint64\_t   | uint64\_t   | int                  |
 
-Unless are the default mappings for array, sequence, and string types unless otherwise specified.
+The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
 
-| IDL type                | C type                 | C++ type            | Python type |
-| ----------------------- | ---------------------- | ------------------- | ----------- |
-| array                   | T [FIXED\_SIZE]        | std::array<T, N>    | list        |
-| unbounded sequence      | struct {size\_t, T * } | std::vector<T>      | list        |
-| bounded sequence        | struct {size\_t, T * } | custom\_class<T, N> | list        |
-| string                  | char *                 | std::string         | str         |
-| bounded string          | char *                 | std::string         | str         |
-| wstring                 | char16\_t *            | std::u16string      | str         |
-| bounded wstring         | char16\_t *            | std::u16string      | str         |
+| IDL type       | C type                 | C++ type            | Python type |
+| -------------- | ---------------------- | ------------------- | ----------- |
+| T[N]           | T[N]                   | std::array<T, N>    | list        |
+| sequence<T>    | struct {size\_t, T * } | std::vector<T>      | list        |
+| sequence<T, N> | struct {size\_t, T * } | custom\_class<T, N> | list        |
+| string         | char *                 | std::string         | str         |
+| string<N>      | char *                 | std::string         | str         |
+| wstring        | char16\_t *            | std::u16string      | str         |
+| wstring<N>     | char16\_t *            | std::u16string      | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -200,15 +200,12 @@ If a cell is blank then the default mapping is used.
 
 | IDL type                     | C type                            | C++ type       | Python type                                     |
 | ---------------------------- | --------------------------------- | -------------- | ----------------------------------------------- |
-| float[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float\_) |
-| sequence<float>              |                                   |                | numpy.ndarray(dtype=numpy.float\_)              |
-| sequence<float, N>           |                                   |                | numpy.ndarray(dtype=numpy.float\_)              |
-| double[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float32) |
-| sequence<double>             |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
-| sequence<double, N>          |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
-| long double[N]               |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float64) |
-| sequence<long double>        |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
-| sequence<long double, N>     |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
+| float[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float32) |
+| sequence<float>              |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
+| sequence<float, N>           |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
+| double[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float64) |
+| sequence<double>             |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
+| sequence<double, N>          |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
 | octet[N]                     |                                   |                | bytes                                           |
 | sequence<octet>              |                                   |                | bytes                                           |
 | sequence<octet, N>           |                                   |                | bytes                                           |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -155,13 +155,13 @@ The table defines how IDL types are mapped to the following programming language
 
 | IDL type    | C type      | C++ type    | Python type          |
 | --------    | ----------- | ----------- | -------------------- |
-| bool        | \_Bool      | bool        | bool                 |
-| octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
-| char        | signed char | char        | str with length 1    |
-| wchar       | char16\_t   | char16\_t   | str with length 1    |
 | float       | float       | float       | float                |
 | double      | double      | double      | float                |
 | long double | long double | long double | float                |
+| char        | signed char | char        | str with length 1    |
+| wchar       | char16\_t   | char16\_t   | str with length 1    |
+| bool        | \_Bool      | bool        | bool                 |
+| octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
 | int8        | int8\_t     | int8\_t     | int                  |
 | uint8       | uint8\_t    | uint8\_t    | int                  |
 | int16       | int16\_t    | int16\_t    | int                  |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -198,42 +198,42 @@ When specified `T` is either one of the types above or an IDL struct.
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.
 
-| IDL type                     | C type                            | C++ type       | Python type                      |
-| ---------------------------- | --------------------------------- | -------------- | -------------------------------- |
-| float[N]                     |                                   |                | numpy.array(dtype=numpy.float\_) |
-| sequence<float>              |                                   |                | numpy.array(dtype=numpy.float\_) |
-| sequence<float, N>           |                                   |                | numpy.array(dtype=numpy.float\_) |
-| double[N]                    |                                   |                | numpy.array(dtype=numpy.float32) |
-| sequence<double>             |                                   |                | numpy.array(dtype=numpy.float32) |
-| sequence<double, N>          |                                   |                | numpy.array(dtype=numpy.float32) |
-| long double[N]               |                                   |                | numpy.array(dtype=numpy.float64) |
-| sequence<long double>        |                                   |                | numpy.array(dtype=numpy.float64) |
-| sequence<long double, N>     |                                   |                | numpy.array(dtype=numpy.float64) |
-| octet[N]                     |                                   |                | bytes                            |
-| sequence<octet>              |                                   |                | bytes                            |
-| sequence<octet, N>           |                                   |                | bytes                            |
-| int8[N]                      |                                   |                | numpy.array(dtype=numpy.int8)    |
-| sequence<int8>               |                                   |                | numpy.array(dtype=numpy.int8)    |
-| sequence<int8, N>            |                                   |                | numpy.array(dtype=numpy.int8)    |
-| uint8[N]                     |                                   |                | numpy.array(dtype=numpy.uint8)   |
-| sequence<uint8>              |                                   |                | numpy.array(dtype=numpy.uint8)   |
-| sequence<uint8, N>           |                                   |                | numpy.array(dtype=numpy.uint8)   |
-| int16[N]                     |                                   |                | numpy.array(dtype=numpy.int16)   |
-| sequence<int16>              |                                   |                | numpy.array(dtype=numpy.int16)   |
-| sequence<int16, N>           |                                   |                | numpy.array(dtype=numpy.int16)   |
-| uint16[N]                    |                                   |                | numpy.array(dtype=numpy.uint16)  |
-| sequence<uint16>             |                                   |                | numpy.array(dtype=numpy.uint16)  |
-| sequence<uint16, N>          |                                   |                | numpy.array(dtype=numpy.uint16)  |
-| int32[N]                     |                                   |                | numpy.array(dtype=numpy.int32)   |
-| sequence<int32>              |                                   |                | numpy.array(dtype=numpy.int32)   |
-| sequence<int32, N>           |                                   |                | numpy.array(dtype=numpy.int32)   |
-| uint32[N]                    |                                   |                | numpy.array(dtype=numpy.uint32)  |
-| sequence<uint32>             |                                   |                | numpy.array(dtype=numpy.uint32)  |
-| sequence<uint32, N>          |                                   |                | numpy.array(dtype=numpy.uint32)  |
-| int64[N]                     |                                   |                | numpy.array(dtype=numpy.int64)   |
-| sequence<int64>              |                                   |                | numpy.array(dtype=numpy.int64)   |
-| sequence<int64, N>           |                                   |                | numpy.array(dtype=numpy.int64)   |
-| uint64[N]                    |                                   |                | numpy.array(dtype=numpy.uint64)  |
-| sequence<uint64>             |                                   |                | numpy.array(dtype=numpy.uint64)  |
-| sequence<uint64, N>          |                                   |                | numpy.array(dtype=numpy.uint64)  |
-| array of string              | struct {size\_t, T * }, size\_t N |                |                                  |
+| IDL type                     | C type                            | C++ type       | Python type                                     |
+| ---------------------------- | --------------------------------- | -------------- | ----------------------------------------------- |
+| float[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float\_) |
+| sequence<float>              |                                   |                | numpy.ndarray(dtype=numpy.float\_)              |
+| sequence<float, N>           |                                   |                | numpy.ndarray(dtype=numpy.float\_)              |
+| double[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float32) |
+| sequence<double>             |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
+| sequence<double, N>          |                                   |                | numpy.ndarray(dtype=numpy.float32)              |
+| long double[N]               |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.float64) |
+| sequence<long double>        |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
+| sequence<long double, N>     |                                   |                | numpy.ndarray(dtype=numpy.float64)              |
+| octet[N]                     |                                   |                | bytes                                           |
+| sequence<octet>              |                                   |                | bytes                                           |
+| sequence<octet, N>           |                                   |                | bytes                                           |
+| int8[N]                      |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int8)    |
+| sequence<int8>               |                                   |                | numpy.ndarray(dtype=numpy.int8)                 |
+| sequence<int8, N>            |                                   |                | numpy.ndarray(dtype=numpy.int8)                 |
+| uint8[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint8)   |
+| sequence<uint8>              |                                   |                | numpy.ndarray(dtype=numpy.uint8)                |
+| sequence<uint8, N>           |                                   |                | numpy.ndarray(dtype=numpy.uint8)                |
+| int16[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int16)   |
+| sequence<int16>              |                                   |                | numpy.ndarray(dtype=numpy.int16)                |
+| sequence<int16, N>           |                                   |                | numpy.ndarray(dtype=numpy.int16)                |
+| uint16[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint16)  |
+| sequence<uint16>             |                                   |                | numpy.ndarray(dtype=numpy.uint16)               |
+| sequence<uint16, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint16)               |
+| int32[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int32)   |
+| sequence<int32>              |                                   |                | numpy.ndarray(dtype=numpy.int32)                |
+| sequence<int32, N>           |                                   |                | numpy.ndarray(dtype=numpy.int32)                |
+| uint32[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint32)  |
+| sequence<uint32>             |                                   |                | numpy.ndarray(dtype=numpy.uint32)               |
+| sequence<uint32, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint32)               |
+| int64[N]                     |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.int64)   |
+| sequence<int64>              |                                   |                | numpy.ndarray(dtype=numpy.int64)                |
+| sequence<int64, N>           |                                   |                | numpy.ndarray(dtype=numpy.int64)                |
+| uint64[N]                    |                                   |                | numpy.ndarray(shape=(N, ), dtype=numpy.uint64)  |
+| sequence<uint64>             |                                   |                | numpy.ndarray(dtype=numpy.uint64)               |
+| sequence<uint64, N>          |                                   |                | numpy.ndarray(dtype=numpy.uint64)               |
+| array of string              | struct {size\_t, T * }, size\_t N |                |                                                 |

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -184,15 +184,15 @@ The next table defines how IDL templated and constructed types are mapped to the
 When specified `T` is either one of the types above or an IDL struct.
 `N` is the upper limit of a bounded type.
 
-| IDL type       | C type                            | C++ type          | Python type |
-| -------------- | --------------------------------- | ----------------- | ----------- |
-| T[N]           | T[N]                              | std::array<T, N>  | list        |
-| sequence<T>    | struct {size\_t, T * }            | std::vector<T>    | list        |
-| sequence<T, N> | struct {size\_t, T * }, size\_t N | std::vector<T, N> | list        |
-| string         | char *                            | std::string       | str         |
-| string<N>      | char *                            | std::string       | str         |
-| wstring        | char16\_t *                       | std::u16string    | str         |
-| wstring<N>     | char16\_t *                       | std::u16string    | str         |
+| IDL type       | C type                            | C++ type         | Python type |
+| -------------- | --------------------------------- | ---------------- | ----------- |
+| T[N]           | T[N]                              | std::array<T, N> | list        |
+| sequence<T>    | struct {size\_t, T * }            | std::vector<T>   | list        |
+| sequence<T, N> | struct {size\_t, T * }, size\_t N | std::vector<T>   | list        |
+| string         | char *                            | std::string      | str         |
+| string<N>      | char *                            | std::string      | str         |
+| wstring        | char16\_t *                       | std::u16string   | str         |
+| wstring<N>     | char16\_t *                       | std::u16string   | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -165,7 +165,7 @@ The next table defines how IDL types are mapped to the following programming lan
 | --------    | -----------      | ------------------------------ | -------------------- |
 | float       | float            | float                          | float                |
 | double      | double           | double                         | float                |
-| long double | long double      | long double                    | float                |
+| long double | long double      | long double[<sup>2</sup>](#ld) | float                |
 | char        | signed char      | char                           | str with length 1    |
 | wchar       | char16\_t        | char16\_t                      | str with length 1    |
 | bool        | \_Bool           | bool                           | bool                 |
@@ -180,6 +180,8 @@ The next table defines how IDL types are mapped to the following programming lan
 | uint64      | uint64\_t        | uint64\_t                      | int                  |
 
 1. <a name="byte"></a>If std::byte is not available then unsigned char is used instead.
+2. <a name="ld"></a>Users should research the support for `long double` with their choice of middleware and platform.
+   For example, it is only [64 bits when using Visual Studio](https://docs.microsoft.com/en-us/cpp/c-language/type-long-double?view=vs-2017).
 
 The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
 When specified `T` is either one of the types above or an IDL struct.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -160,25 +160,25 @@ The next table defines how IDL types are mapped to the following programming lan
 * C++11 (or higher)
 * Python 3 (or higher)
 
-| IDL type    | C type      | C++ type                       | Python type          |
-| --------    | ----------- | ------------------------------ | -------------------- |
-| float       | float       | float                          | float                |
-| double      | double      | double                         | float                |
-| long double | long double | long double                    | float                |
-| char        | signed char | char                           | str with length 1    |
-| wchar       | char16\_t   | char16\_t                      | str with length 1    |
-| bool        | \_Bool      | bool                           | bool                 |
-| octet       | uint8\_t    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |
-| int8        | int8\_t     | int8\_t                        | int                  |
-| uint8       | uint8\_t    | uint8\_t                       | int                  |
-| int16       | int16\_t    | int16\_t                       | int                  |
-| uint16      | uint16\_t   | uint16\_t                      | int                  |
-| int32       | int32\_t    | int32\_t                       | int                  |
-| uint32      | uint32\_t   | uint32\_t                      | int                  |
-| int64       | int64\_t    | int64\_t                       | int                  |
-| uint64      | uint64\_t   | uint64\_t                      | int                  |
+| IDL type    | C type           | C++ type                       | Python type          |
+| --------    | -----------      | ------------------------------ | -------------------- |
+| float       | float            | float                          | float                |
+| double      | double           | double                         | float                |
+| long double | long double      | long double                    | float                |
+| char        | signed char      | char                           | str with length 1    |
+| wchar       | char16\_t        | char16\_t                      | str with length 1    |
+| bool        | \_Bool           | bool                           | bool                 |
+| octet       | unsigned char    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |
+| int8        | int8\_t          | int8\_t                        | int                  |
+| uint8       | uint8\_t         | uint8\_t                       | int                  |
+| int16       | int16\_t         | int16\_t                       | int                  |
+| uint16      | uint16\_t        | uint16\_t                      | int                  |
+| int32       | int32\_t         | int32\_t                       | int                  |
+| uint32      | uint32\_t        | uint32\_t                      | int                  |
+| int64       | int64\_t         | int64\_t                       | int                  |
+| uint64      | uint64\_t        | uint64\_t                      | int                  |
 
-1. <a name="byte"></a>If std::byte is not available then uint8\_t is used instead.
+1. <a name="byte"></a>If std::byte is not available then unsigned char is used instead.
 
 The next table defines how IDL templated and constructed types are mapped to the programming languages (unless specified otherwise below).
 When specified `T` is either one of the types above or an IDL struct.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -147,7 +147,7 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 ### Constraint Checking
 
-Generated code for messages is guaranteed to enforce constraints only when a message is published.
+Generated code for messages is only guaranteed to enforce constraints when a message is published.
 For example, there might not be an error when a field constrained to be a fixed size array is assigned an array with the wrong size.
 In the future constraints might be checked when a field is set.
 Users of generated message code should assume constraints are enforced when fields are set.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -150,7 +150,7 @@ For now only a one-dimensional, fixed-size array is supported though.
 Generated code for messages is only guaranteed to enforce constraints when a message is published.
 For example, there might not be an error when a field constrained to be a fixed size array is assigned an array with the wrong size.
 In the future constraints might be checked when a field is set.
-Users of generated message code should assume constraints are enforced when fields are set.
+Users of generated message code should assume constraints are enforced when fields are set or modified.
 
 ### Type Mapping
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -164,11 +164,11 @@ The table defines how IDL types are mapped to the following programming language
 | long double | long double | long double | float                |
 | int8        | int8\_t     | int8\_t     | int                  |
 | uint8       | uint8\_t    | uint8\_t    | int                  |
-| int16       | int16       | int16       | int                  |
-| uint16      | uint16      | uint16      | int                  |
-| int32       | int32       | int32       | int                  |
-| uint32      | uint32      | uint32      | int                  |
-| int64       | int64       | int64       | int                  |
+| int16       | int16\_t    | int16\_t    | int                  |
+| uint16      | uint16\_t   | uint16\_t   | int                  |
+| int32       | int32\_t    | int32\_t    | int                  |
+| uint32      | uint32\_t   | uint32\_t   | int                  |
+| int64       | int64\_t    | int64\_t    | int                  |
 | uint64      | uint64\_t   | uint64\_t   | int                  |
 
 Unless are the default mappings for array, sequence, and string types unless otherwise specified.

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -150,21 +150,22 @@ For now only a one-dimensional, fixed-size array is supported though.
 IDL types mapped to different types in different languages.
 
 
-| IDL type | C type      | C++ type    | Python type          |
-| -------- | ----------- | ----------- | -------------------- |
-| bool     | \_Bool      | bool        | bool                 |
-| octet    | uint8\_t    | uint8\_t    | bytes with length 1  |
-| char     | signed char | char        | str with length 1    |
-| float    | float       | float       | float                |
-| double   | double      | double      | float                |
-| int8     | int8\_t     | int8\_t     | int                  |
-| uint8    | uint8\_t    | uint8\_t    | int                  |
-| int16    | int16       | int16       | int                  |
-| uint16   | uint16      | uint16      | int                  |
-| int32    | int32       | int32       | int                  |
-| uint32   | uint32      | uint32      | int                  |
-| int64    | int64       | int64       | int                  |
-| uint64   | uint64\_t   | uint64\_t   | int                  |
+| IDL type    | C type      | C++ type    | Python type          |
+| --------    | ----------- | ----------- | -------------------- |
+| bool        | \_Bool      | bool        | bool                 |
+| octet       | uint8\_t    | uint8\_t    | bytes with length 1  |
+| char        | signed char | char        | str with length 1    |
+| float       | float       | float       | float                |
+| double      | double      | double      | float                |
+| long double | long double | long double | float                |
+| int8        | int8\_t     | int8\_t     | int                  |
+| uint8       | uint8\_t    | uint8\_t    | int                  |
+| int16       | int16       | int16       | int                  |
+| uint16      | uint16      | uint16      | int                  |
+| int32       | int32       | int32       | int                  |
+| uint32      | uint32      | uint32      | int                  |
+| int64       | int64       | int64       | int                  |
+| uint64      | uint64\_t   | uint64\_t   | int                  |
 
 Unless are the default mappings for array, sequence, and string types unless otherwise specified.
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -147,8 +147,11 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 ### Type Mapping
 
-IDL types mapped to different types in different languages.
+The table defines how IDL types are mapped to the following programming languages:
 
+* C11 (or higher)
+* C++11 (or higher)
+* Python 3 (or higher)
 
 | IDL type    | C type      | C++ type    | Python type          |
 | --------    | ----------- | ----------- | -------------------- |

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -253,11 +253,11 @@ Code generation uses the generated file.
 | -------- | ------------------ |
 | bool     | boolean            |
 | byte     | octet              |
-| char     | short              |
+| char     | int8               |
 | float32  | float              |
 | float64  | double             |
-| int8     | octet              |
-| uint8    | octet              |
+| int8     | int8               |
+| uint8    | uint8              |
 | int16    | short              |
 | uint16   | unsigned short     |
 | int32    | long               |

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -241,3 +241,34 @@ Depending on the type the following values are valid:
 A service file contains two message definitions which are separated by a line which only contains three dashes:
 
     ---
+
+## Conversion to IDL
+Code is generated for defined interfaces to be usable by different client libraries.
+Interfaces described using the legacy format are first converted to [IDL](articles/idl_interface_definition.html).
+Code generation uses the generated file.
+
+### Mapping to IDL types
+
+| ROS type | IDL type           |
+| -------- | ------------------ |
+| bool     | boolean            |
+| byte     | octet              |
+| char     | char               |
+| float32  | float              |
+| float64  | double             |
+| int8     | octet              |
+| uint8    | octet              |
+| int16    | short              |
+| uint16   | unsigned short     |
+| int32    | long               |
+| uint32   | unsigned long      |
+| int64    | long long          |
+| uint64   | unsigned long long |
+| string   | string             |
+
+| ROS type                | IDL type       |
+| ----------------------- | -------------- |
+| static array            | T\[N\]         |
+| unbounded dynamic array | sequence<T>    |
+| bounded dynamic array   | sequence<T, N> |
+| bounded string          | string<N>      |

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -253,7 +253,7 @@ Code generation uses the generated file.
 | -------- | ------------------ |
 | bool     | boolean            |
 | byte     | octet              |
-| char     | char               |
+| char     | short              |
 | float32  | float              |
 | float64  | double             |
 | int8     | octet              |

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -266,9 +266,9 @@ Code generation uses the generated file.
 | uint64   | unsigned long long |
 | string   | string             |
 
-| ROS type                | IDL type       |
-| ----------------------- | -------------- |
-| static array            | T\[N\]         |
-| unbounded dynamic array | sequence<T>    |
-| bounded dynamic array   | sequence<T, N> |
-| bounded string          | string<N>      |
+| ROS type                | IDL type         |
+| ----------------------- | ---------------- |
+| static array            | array            |
+| unbounded dynamic array | sequence         |
+| bounded dynamic array   | bounded sequence |
+| bounded string          | bounded string   |

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -253,7 +253,7 @@ Code generation uses the generated file.
 | -------- | ------------------ |
 | bool     | boolean            |
 | byte     | octet              |
-| char     | int8               |
+| char     | uint8              |
 | float32  | float              |
 | float64  | double             |
 | int8     | int8               |


### PR DESCRIPTION
This adds mappings between IDL types and other types.