### PR TITLE
Mention there are exceptions to the msg naming rule, intended for internal use only

### DIFF
--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -137,6 +137,7 @@ Each file contains a single message or service.
 Message files use the extension `.msg`, service files use the extension `.srv`.
 
 Both file names must use an upper camel case name and only consist of alphanumeric characters.
+Note that some message files are permitted to deviate from this pattern (such as `MyService_Request.msg` and `MyService_Response.msg` which are generated automatically from `MyService.srv`), but that is only intended for internally-generated message files, not those written by users.
 
 ### Naming of fields
 

--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -137,7 +137,7 @@ Each file contains a single message or service.
 Message files use the extension `.msg`, service files use the extension `.srv`.
 
 Both file names must use an upper camel case name and only consist of alphanumeric characters.
-Note that some message files are permitted to deviate from this pattern (such as `MyService_Request.msg` and `MyService_Response.msg` which are generated automatically from `MyService.srv`), but that is only intended for internally-generated message files, not those written by users.
+Note that some message files are permitted to deviate from this pattern (such as `MyService_Request.msg` and `MyService_Response.msg` which are generated automatically from `MyService.srv`), but the exceptions are only intended for internally-generated message files, not those written by users.
 
 ### Naming of fields
 


### PR DESCRIPTION
`rosidl_parser` allows some exceptions (currently `_Request` and `_Response` suffixes, and `Sample_` prefixes (for opensplice specifically)). It's not trivial to prevent users from exploiting these exceptions, so instead document that it is not permitted.