### PR TITLE
fix idl type name for boolean

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -168,7 +168,7 @@ The next table defines how IDL types are mapped to the following programming lan
 | long double | long double      | long double[<sup>2</sup>](#ld) | float                |
 | char        | unsigned char    | unsigned char                  | str with length 1    |
 | wchar       | char16\_t        | char16\_t                      | str with length 1    |
-| bool        | \_Bool           | bool                           | bool                 |
+| boolean     | \_Bool           | bool                           | bool                 |
 | octet       | unsigned char    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |
 | int8        | int8\_t          | int8\_t                        | int                  |
 | uint8       | uint8\_t         | uint8\_t                       | int                  |


### PR DESCRIPTION
Fixes the IDL type name in the mapping table for `boolean` as defined in "7.4.1.4.4.2.5 Boolean Type".