### PR TITLE
uint64 maps to unsigned long long

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -99,7 +99,7 @@ the DDS-XTypes specification 1.2 defines it with 16-bit.
 | int32          | int                 |
 | uint32         | unsigned int        |
 | int64          | long                |
-| uint64         | unsigned long       |
+| uint64         | unsigned long long  |
 
 ### Template Types
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -96,9 +96,9 @@ the DDS-XTypes specification 1.2 defines it with 16-bit.
 | -------------- | ------------------- |
 | int16          | short               |
 | uint16         | unsigned short      |
-| int32          | int                 |
-| uint32         | unsigned int        |
-| int64          | long                |
+| int32          | long                |
+| uint32         | unsigned long       |
+| int64          | long long           |
 | uint64         | unsigned long long  |
 
 ### Template Types


### PR DESCRIPTION
Previously article mapped uint64 to `unsigned long` which is synonymous with `unsigned int`.