### PR TITLE
Fix RVM issue in CI by switching Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: xenial
 language: ruby
 rvm:
-- 2.5
+- 2.6
 sudo: false
 install:
 - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.5
+- 2.6.0
 sudo: false
 install:
 - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 10
 - npm install remark-cli remark-lint remark-lint-sentence-newline
 script:
-- bundler --version
 - bundle exec jekyll build
 - ./node_modules/remark-cli/cli.js --frail articles/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-dist: xenial
 language: ruby
 rvm:
-- 2.6
+- 2.5
 sudo: false
 install:
 - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.6
+- 2.5
 sudo: false
 install:
 - gem install bundler --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 10
 - npm install remark-cli remark-lint remark-lint-sentence-newline
 script:
-- jekyll build
+- bundler --version
+- bundle exec jekyll build
 - ./node_modules/remark-cli/cli.js --frail articles/
 
 # branch whitelist


### PR DESCRIPTION
Although I suspect this is an issue with travis's networking on their VMs based on the curl output:

```
$ rvm use 2.6 --install --binary --fuzzy
curl: (22) The requested URL returned error: 403 Forbidden
Required ruby-2.6 is not installed - installing.
curl: (22) The requested URL returned error: 403 Forbidden
Searching for binary rubies, this might take some time.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm ruby-2.6 do rvm gemset create ' first, or append '--create'.
The command "rvm use 2.6 --install --binary --fuzzy" failed and exited with 2 during .
```

As of this morning, the result is a 404 not a 403. If I install rvm in a local trusty container, I can get the binary from... rubies.travis-ci.org... and it installs successfully.

```
# rvm use ruby-2.6 --install --fuzzy --binary
Required ruby-2.6.1 is not installed - installing.
Searching for binary rubies, this might take some time.
Found remote file https://rubies.travis-ci.org/ubuntu/14.04/x86_64/ruby-2.6.1.tar.bz2
```

I don't expect falling back to ruby 2.5 will fix the travis issue but this is a starting point to try and get it up again.