### PR TITLE
map sequence to Python array.array()

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -227,7 +227,8 @@ If a cell is blank then the default mapping is used.
 
 | IDL type                     |   | C type                            | C++ type       | Python type                                     |   |
 | ---------------------------- | - | --------------------------------- | -------------- | ----------------------------------------------- | - |
-| T[N]<br>sequence\<T><br>sequence<T, N> | for numeric types T:<br>float, double,<br>int8, uint8,<br>int16, uint16,<br>int32, uint32,<br>int64, uint64 | - | - | numpy.ndarray(shape=(N, ), dtype=numpy.DT) | where DT is determined by T:<br>float -> float32, double -> float64,<br>intX -> intX, uintX -> uintX, |
+| T[N] | for numeric types T:<br>float, double,<br>int8, uint8,<br>int16, uint16,<br>int32, uint32,<br>int64, uint64 | - | - | numpy.ndarray(<br>&nbsp;&nbsp;shape=(N, ),<br>&nbsp;&nbsp;dtype=numpy.DT) | where DT is determined by T:<br>float -> float32,<br>double -> float64,<br>intX -> intX,<br>uintX -> uintX |
+| sequence\<T><br>sequence<T, N> | for numeric types T:<br>float, double,<br>int8, uint8,<br>int16, uint16,<br>int32, uint32,<br>int64, uint64 | - | - | array.array(typecode=TC) | where TC is determined by T:<br>float -> f,<br>double -> d,<br>int8 -> b, uint8 -> B,<br>int16 -> h, uint16 -> H,<br>int32 -> l, uint32 -> L,<br>int64 -> q, uint64 -> Q |
 | octet[N]                     |   | -                                 | -              | bytes                                           | |
 | sequence\<octet>              |   | -                                 | -              | bytes                                           | |
 | sequence<octet, N>           |   | -                                 | -              | bytes                                           | |


### PR DESCRIPTION
This patch proposes to map (un)bounded sequences of numerics to [array.array](https://docs.python.org/3/library/array.html#array.array) instead of [numpy.ndarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html).

An array provides the same interface as a Python list. It only uses memory closer to what the C representation needs (similar even though slightly higher than `numpy`) and also checks the value range of each item based on the typecode.