### PR TITLE
Add section on uniquely identifier interface definitions

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -40,7 +40,7 @@ Both line comments (`//`) as well as block comments (`/* ... */`) are being supp
 
 #### 7.2.3 Identifiers
 
-An identifier must start with an is an ASCII alphabetic characteran followed by any number of ASCII alphabetic, digit and underscore (`_`) characters.
+An identifier must start with an ASCII alphabetic character followed by any number of ASCII alphabetic, digit and underscore (`_`) characters.
 
 #### 7.2.6 Literals
 
@@ -129,7 +129,7 @@ the DDS-XTypes specification 1.2 defines it with 16-bit.
 | ---------------------- | ---------------------------------------------------------- |
 | sequence\<type\_spec>  | sequence of items of the specific type\_spec               |
 |                        | the sequence is unbounded and no maximum size is specified |
-| sequence<type_spec, N> | sequence of of up to N items of the specified type\_spec   |
+| sequence<type_spec, N> | sequence of up to N items of the specified type\_spec      |
 |                        | the sequence is bounded and contain between 0 and N items  |
 
 #### 7.4.1.4.4.3.2 Strings
@@ -158,6 +158,60 @@ An enumerated type consist of an ordered list of enumerators.
 
 A multidimensional, fixed-size array is defined by the type of each item and the explicit sizes for each dimension.
 For now only a one-dimensional, fixed-size array is supported though.
+
+### Interface Identification
+
+#### Uniform Resource Name (URN)
+
+Following 7.5.1 from the IDL 4.2 specification, every IDL definition can be uniquely identified with a qualified name of the form
+**<scoped\_name>::<identifier>**.
+In addition to the specification, the scope of an IDL definition is prefixed with the package name from which the defintions is derived.
+This is to guarantee uniqueness of definitions across packages (under the assumption that package names are unique).
+Therefore, each interface defintion can be resolved with a URN of the form: **<package\_name>/<scoped\_name>/<identifier>**.
+
+#### Uniform Resource Locator (URL)
+
+For source code to use an interface (e.g. include or import) there needs to be a way to reference the file containing the defintion.
+To reference the location of an IDL defintion we use a URL of the form: **rosidl:<package\_name>/<subfolder>/<file>**.
+Where *<subfolder>* is the relative path from the root of the package where generated defintions can be found.
+
+#### Example
+
+Imagine we have a package `foo_pkg` containing an IDL file `Bar.idl` with the following contents:
+
+```idl
+struct MsgA {
+  boolean bool_member;
+};
+
+module bar {
+  const int8 MY_CONSTANT = 42;
+
+  struct MsgB {
+    int8 int_member;
+  };
+
+  module baz {
+    struct MsgC {
+      string string_member;
+    };
+  };
+};
+```
+
+Also imagine the message generation pipeline places the generated implementation to a subfolder `interface`.
+
+Then, we can reference the interfaces with the following URNs:
+
+- `foo_pkg/MsgA`
+- `foo_pkg/bar/MY_CONSTANT`
+- `foo_pkg/bar/MsgB`
+- `foo_pkg/bar/baz/MsgC`
+
+And all can be located with the URL: `rosidl:foo_pkg/interface/Bar`.
+
+For example, the definitions could be included in C++ with `#include <foo_pkg/interface/Bar.hpp>`
+or imported in Python with `import foo_pkg.interface.Bar`.
 
 ### Annotations
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -202,17 +202,17 @@ module bar {
 
 Also imagine the message generation pipeline places the generated implementation to a subfolder `interface`.
 
-Then, we can reference the interfaces with the following URNs:
+Then, we can reference the interfaces with the following URIs:
 
 - `rosidl:foo_pkg/MsgA`
 - `rosidl:foo_pkg/bar/MY_CONSTANT`
 - `rosidl:foo_pkg/bar/MsgB`
 - `rosidl:foo_pkg/bar/baz/MsgC`
 
-And all can be located with the URL: `package://foo_pkg/interface/Bar`.
+And all can be located with the URL: `package://foo_pkg/interface/bar`.
 
-For example, the definitions could be included in C++ with `#include <foo_pkg/interface/Bar.hpp>`
-or imported in Python with `import foo_pkg.interface.Bar`.
+For example, the definitions could be included in C++ with `#include <foo_pkg/interface/bar.hpp>`
+or imported in Python with `import foo_pkg.interface.bar`.
 
 ### Annotations
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -164,10 +164,10 @@ For now only a one-dimensional, fixed-size array is supported though.
 #### Uniform Resource Name (URN)
 
 Following 7.5.1 from the IDL 4.2 specification, every IDL definition can be uniquely identified with a qualified name of the form
-**<scoped\_name>::<identifier>**.
-In addition to the specification, the scope of an IDL definition is prefixed with the package name from which the defintions is derived.
+**\<scoped\_name>::\<identifier>**.
+In addition to the specification, the scope of an IDL definition is prefixed with the package name from which the defintion is derived.
 This is to guarantee uniqueness of definitions across packages (under the assumption that package names are unique).
-Therefore, each interface defintion can be resolved with a URN of the form: **<package\_name>/<scoped\_name>/<identifier>**.
+Therefore, each interface defintion can be resolved with a URN of the form: **\<package\_name>/\<scoped\_name>/\<identifier>**.
 
 #### Uniform Resource Locator (URL)
 

--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -161,18 +161,19 @@ For now only a one-dimensional, fixed-size array is supported though.
 
 ### Interface Identification
 
-#### Uniform Resource Name (URN)
+#### Uniform Resource Identifier (URI)
 
 Following 7.5.1 from the IDL 4.2 specification, every IDL definition can be uniquely identified with a qualified name of the form
 **\<scoped\_name>::\<identifier>**.
 In addition to the specification, the scope of an IDL definition is prefixed with the package name from which the defintion is derived.
 This is to guarantee uniqueness of definitions across packages (under the assumption that package names are unique).
-Therefore, each interface defintion can be resolved with a URN of the form: **\<package\_name>/\<scoped\_name>/\<identifier>**.
+Therefore, each interface defintion can be resolved with a URI of the form: **rosidl:\<package\_name>/\<scoped\_name>/\<identifier>**.
+Where *\<scoped\_name\>* is one or more names separated by forward slashes ("/").
 
 #### Uniform Resource Locator (URL)
 
 For source code to use an interface (e.g. include or import) there needs to be a way to reference the file containing the defintion.
-To reference the location of an IDL defintion we use a URL of the form: **rosidl:<package\_name>/<subfolder>/<file>**.
+To reference the location of an IDL defintion we use a URL of the form: **package://<package\_name>/<subfolder>/<file>**.
 Where *<subfolder>* is the relative path from the root of the package where generated defintions can be found.
 
 #### Example
@@ -203,12 +204,12 @@ Also imagine the message generation pipeline places the generated implementation
 
 Then, we can reference the interfaces with the following URNs:
 
-- `foo_pkg/MsgA`
-- `foo_pkg/bar/MY_CONSTANT`
-- `foo_pkg/bar/MsgB`
-- `foo_pkg/bar/baz/MsgC`
+- `rosidl:foo_pkg/MsgA`
+- `rosidl:foo_pkg/bar/MY_CONSTANT`
+- `rosidl:foo_pkg/bar/MsgB`
+- `rosidl:foo_pkg/bar/baz/MsgC`
 
-And all can be located with the URL: `rosidl:foo_pkg/interface/Bar`.
+And all can be located with the URL: `package://foo_pkg/interface/Bar`.
 
 For example, the definitions could be included in C++ with `#include <foo_pkg/interface/Bar.hpp>`
 or imported in Python with `import foo_pkg.interface.Bar`.

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -38,21 +38,29 @@ Each field is described by a *type* and a *name*.
 
 A single data structure is called *message*.
 Each message has a *name*.
-Together with the name of the *package* a message can be uniquely identified.
 
 ### Services
 
 For request / reply style communication the two exchanged data structures are related.
 These pairs of data structures are called *services*.
-A service is identified by its *name* and the *package* it is in.
 Each service describes two messages, one for the request data structure, one for the reply data structure.
 
 ### Actions
 
 For longer running request / reply style communication with feedback about the progress the exchanged data structures are related.
 These triplets of data structures are called *actions*.
-An action is identified by its *name* and the *package* it is in.
 Each action describes three messages, one for the goal data structure, one for the result data structure, and one for the feedback data structure.
+
+### Identifying data structures
+
+Every data structure can be uniquely identified with three pieces of information:
+
+1. **Package** - the name of the package containing the data structure definition.
+2. **Subfolders** - the list of subfolders within the package where the data structure defintion can be found.
+3. **Name** - the name of the data structure.
+
+For example, a message with the name `Foo` in subfolder `msg` of the package `bar` has the unique identifier `bar/msg/Foo`.
+Here, `/` is used as a separator, but in practice any delimeter could be used.
 
 ### Field types
 

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -71,8 +71,8 @@ as described by [IDL - Interface Identification](idl_interface_definition.html#i
 
 The underlying message definitions that make up a service are located in the same file (ie. have the same URL) and are in the `srv` namespace:
 
-- URN: `<package_name>/srv/<name>\_Request`
-- URN: `<package_name>/srv/<name>\_Response`
+- URN: `<package_name>/srv/<name>_Request`
+- URN: `<package_name>/srv/<name>_Response`
 
 #### Actions
 
@@ -81,9 +81,9 @@ The underlying message definitions that make up a service are located in the sam
 
 The underlying message definitions that make up an action are located in the same file (ie. have the same URL) and are in the `action` namespace:
 
-- URN: `<package_name>/action/<name>\_Goal`
-- URN: `<package_name>/action/<name>\_Result`
-- URN: `<package_name>/action/<name>\_Feedback`
+- URN: `<package_name>/action/<name>_Goal`
+- URN: `<package_name>/action/<name>_Result`
+- URN: `<package_name>/action/<name>_Feedback`
 
 ### Field types
 

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -38,12 +38,15 @@ Each field is described by a *type* and a *name*.
 
 A single data structure is called *message*.
 Each message has a *name*.
+Together with the name of the *package* a message can be uniquely identified.
+A message has the URN: package/msg/name`.
 
 ### Services
 
 For request / reply style communication the two exchanged data structures are related.
 These pairs of data structures are called *services*.
 Each service describes two messages, one for the request data structure, one for the reply data structure.
+Together with the name of the *package* a
 
 ### Actions
 
@@ -53,14 +56,34 @@ Each action describes three messages, one for the goal data structure, one for t
 
 ### Identifying data structures
 
-Every data structure can be uniquely identified with three pieces of information:
+Every data structure can be uniquely referenced with a *uniform resource name* (URN) and a *uniform resource locator* (URL)
+as described by [IDL - Interface Identification](idl_interface_definition.html#interface-identification)
 
-1. **Package** - the name of the package containing the data structure definition.
-2. **Subnamespaces** - the list of namespaces within the package where the data structure is defined.
-3. **Name** - the name of the data structure.
+#### Messages
 
-For example, a message with the name `Foo` in the namespace `msg` of the package `bar` has the unique identifier `bar/msg/Foo`.
-Here, `/` is used as a separator, but in practice any delimeter could be used.
+- URN: `<package_name>/msg/<name>`
+- URL: `<package_name>/msg/<name>`
+
+#### Services
+
+- URN: `<package_name>/srv/<name>`
+- URL: `<package_name>/srv/<name>`
+
+The underlying message definitions that make up a service are located in the same file (ie. have the same URL) and are in the `srv` namespace:
+
+- URN: `<package_name>/srv/<name>\_Request`
+- URN: `<package_name>/srv/<name>\_Response`
+
+#### Actions
+
+- URN: `<package_name>/action/<name>`
+- URL: `<package_name>/action/<name>`
+
+The underlying message definitions that make up an action are located in the same file (ie. have the same URL) and are in the `action` namespace:
+
+- URN: `<package_name>/action/<name>\_Goal`
+- URN: `<package_name>/action/<name>\_Result`
+- URN: `<package_name>/action/<name>\_Feedback`
 
 ### Field types
 

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -56,10 +56,10 @@ Each action describes three messages, one for the goal data structure, one for t
 Every data structure can be uniquely identified with three pieces of information:
 
 1. **Package** - the name of the package containing the data structure definition.
-2. **Subfolders** - the list of subfolders within the package where the data structure defintion can be found.
+2. **Subnamespaces** - the list of namespaces within the package where the data structure is defined.
 3. **Name** - the name of the data structure.
 
-For example, a message with the name `Foo` in subfolder `msg` of the package `bar` has the unique identifier `bar/msg/Foo`.
+For example, a message with the name `Foo` in the namespace `msg` of the package `bar` has the unique identifier `bar/msg/Foo`.
 Here, `/` is used as a separator, but in practice any delimeter could be used.
 
 ### Field types

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -53,34 +53,34 @@ Each action describes three messages, one for the goal data structure, one for t
 
 ### Identifying data structures
 
-Every data structure can be uniquely referenced with a *uniform resource name* (URN) and a *uniform resource locator* (URL)
+Every data structure can be uniquely referenced with a *uniform resource identifier* (URI) and a *uniform resource locator* (URL)
 as described by [IDL - Interface Identification](idl_interface_definition.html#interface-identification)
 
 #### Messages
 
-- URN: `<package_name>/msg/<name>`
-- URL: `<package_name>/msg/<name>`
+- URI: `rosidl:<package_name>/msg/<name>`
+- URL: `package://<package_name>/msg/<name>`
 
 #### Services
 
-- URN: `<package_name>/srv/<name>`
-- URL: `<package_name>/srv/<name>`
+- URI: `rosidl:<package_name>/srv/<name>`
+- URL: `package://<package_name>/srv/<name>`
 
 The underlying message definitions that make up a service are located in the same file (ie. have the same URL) and are in the `srv` namespace:
 
-- URN: `<package_name>/srv/<name>_Request`
-- URN: `<package_name>/srv/<name>_Response`
+- URI: `rosidl:<package_name>/srv/<name>_Request`
+- URI: `package://<package_name>/srv/<name>_Response`
 
 #### Actions
 
-- URN: `<package_name>/action/<name>`
-- URL: `<package_name>/action/<name>`
+- URI: `rosidl:<package_name>/action/<name>`
+- URL: `package://<package_name>/action/<name>`
 
 The underlying message and service definitions that make up an action are located in the same file (ie. have the same URL) and are in the `action` namespace:
 
-- URN: `<package_name>/action/<name>_Goal`
-- URN: `<package_name>/action/<name>_Result`
-- URN: `<package_name>/action/<name>_Feedback`
+- URI: `rosidl:<package_name>/action/<name>_Goal`
+- URI: `rosidl:<package_name>/action/<name>_Result`
+- URI: `rosidl:<package_name>/action/<name>_Feedback`
 
 ### Field types
 

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -76,7 +76,7 @@ The underlying message definitions that make up a service are located in the sam
 - URN: `<package_name>/action/<name>`
 - URL: `<package_name>/action/<name>`
 
-The underlying message definitions that make up an action are located in the same file (ie. have the same URL) and are in the `action` namespace:
+The underlying message and service definitions that make up an action are located in the same file (ie. have the same URL) and are in the `action` namespace:
 
 - URN: `<package_name>/action/<name>_Goal`
 - URN: `<package_name>/action/<name>_Result`

--- a/articles/143_legacy_interface_definition.md
+++ b/articles/143_legacy_interface_definition.md
@@ -38,15 +38,12 @@ Each field is described by a *type* and a *name*.
 
 A single data structure is called *message*.
 Each message has a *name*.
-Together with the name of the *package* a message can be uniquely identified.
-A message has the URN: package/msg/name`.
 
 ### Services
 
 For request / reply style communication the two exchanged data structures are related.
 These pairs of data structures are called *services*.
 Each service describes two messages, one for the request data structure, one for the reply data structure.
-Together with the name of the *package* a
 
 ### Actions
 


### PR DESCRIPTION
Follow up from https://github.com/ros2/rmw_opensplice/pull/263#discussion_r267590563

This is a proposal for uniquely identifying ROS interfaces that does not make any assumptions about the subfolder(s) where the interface definitions are found.

