### PR TITLE
char now maps to int in python

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -191,7 +191,7 @@ The next table defines how IDL types are mapped to the following programming lan
 | float       | float            | float                          | float                |
 | double      | double           | double                         | float                |
 | long double | long double      | long double[<sup>2</sup>](#ld) | float                |
-| char        | unsigned char    | unsigned char                  | str with length 1    |
+| char        | unsigned char    | unsigned char                  | int                  |
 | wchar       | char16\_t        | char16\_t                      | str with length 1    |
 | boolean     | \_Bool           | bool                           | bool                 |
 | octet       | unsigned char    | std::byte[<sup>1</sup>](#byte) | bytes with length 1  |


### PR DESCRIPTION
Submitting this documentation fix to match behavior observed using the nightly archive.
It may be that the code is not yet behaving like the design doc, in which case feel free to close this PR.

---
Additional information:

How to reproduce the issue:
```
>>> from test_msgs.msg import Primitives
>>> a = Primitives()
>>> a.char_value = 'a'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/ros/crystal/lib/python3.6/site-packages/test_msgs/msg/_primitives.py", line 186, in char_value
    "The 'char_value' field must of type 'int'"
AssertionError: The 'char_value' field must of type 'int'
```
The same code works on ROS 2 Crystal

The generated IDL file says that the field `char_values` is `uint8` and not `char`:
```
module test_msgs {
  module msg {
    struct Primitives {
      boolean bool_value;

      octet byte_value;

      uint8 char_value;

      float float32_value;
```