### PR TITLE
legacy char now maps to int in python

### DIFF
--- a/articles/114_generated_interfaces_python.md
+++ b/articles/114_generated_interfaces_python.md
@@ -59,7 +59,7 @@ The Python module `<package_name>.msg` / `<package_name>.srv` exports all messag
 | -------- | ---------------------------- |
 | bool     | builtins.bool                |
 | byte     | builtins.bytes with length 1 |
-| char     | builtins.str with length 1   |
+| char     | builtins.int                 |
 | float32  | builtins.float               |
 | float64  | builtins.float               |
 | int8     | builtins.int                 |


### PR DESCRIPTION
redo of https://github.com/ros2/design/pull/221 but targeting the legacy design doc for `msg`.