### PR TITLE
escape < to fix rendering

### DIFF
--- a/articles/142_idl.md
+++ b/articles/142_idl.md
@@ -127,9 +127,9 @@ the DDS-XTypes specification 1.2 defines it with 16-bit.
 
 | IDL type               | Value range                                                |
 | ---------------------- | ---------------------------------------------------------- |
-| sequence<type_spec>    | sequence of items of the specific type_spec                |
+| sequence\<type\_spec>  | sequence of items of the specific type\_spec               |
 |                        | the sequence is unbounded and no maximum size is specified |
-| sequence<type_spec, N> | sequence of of up to N items of the specified type_spec    |
+| sequence<type_spec, N> | sequence of of up to N items of the specified type\_spec   |
 |                        | the sequence is bounded and contain between 0 and N items  |
 
 #### 7.4.1.4.4.3.2 Strings
@@ -215,12 +215,12 @@ When specified `T` is either one of the types above or an IDL struct.
 | IDL type       | C type                            | C++ type         | Python type |
 | -------------- | --------------------------------- | ---------------- | ----------- |
 | T[N]           | T[N]                              | std::array<T, N> | list        |
-| sequence<T>    | struct {size\_t, T * }            | std::vector<T>   | list        |
-| sequence<T, N> | struct {size\_t, T * }, size\_t N | std::vector<T>   | list        |
+| sequence\<T>   | struct {size\_t, T * }            | std::vector\<T>  | list        |
+| sequence<T, N> | struct {size\_t, T * }, size\_t N | std::vector\<T>  | list        |
 | string         | char *                            | std::string      | str         |
-| string<N>      | char *                            | std::string      | str         |
+| string\<N>     | char *                            | std::string      | str         |
 | wstring        | char16\_t *                       | std::u16string   | str         |
-| wstring<N>     | char16\_t *                       | std::u16string   | str         |
+| wstring\<N>    | char16\_t *                       | std::u16string   | str         |
 
 These array and sequence types have special mappings.
 If a cell is blank then the default mapping is used.


### PR DESCRIPTION
Reading this document on design.ros2.org. It appears several lines did not render properly. e.g.
`sequence<T>` renders as `sequence`