### PR TITLE
use consistent naming of ROS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ROS 2.0 design
+# ROS 2 design
 
 This repository is a [Jekyll](http://jekyllrb.com/) website hosted on [Github Pages](http://pages.github.com/) at http://design.ros2.org/.
 
-The repository/website is meant to be a point around which users can collaborate on the ROS 2.0 design efforts as well as capture those discussions for posterity.
+The repository/website is meant to be a point around which users can collaborate on the ROS 2 design efforts as well as capture those discussions for posterity.
 
 The best mailing list for discussing these topics is [ros-sig-ng-ros@googlegroups.com](mailto:ros-sig-ng-ros@googlegroups.com).
 You can view the archives [here](https://groups.google.com/forum/?fromgroups#!forum/ros-sig-ng-ros)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: ROS 2 Design
-description: "Distilled design documents related to the ROS 2.0 effort"
+description: "Distilled design documents related to the ROS 2 effort"
 
 url: http://design.ros2.org
 repo: https://github.com/ros2/design

--- a/articles/010_why_ros2.md
+++ b/articles/010_why_ros2.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Why ROS 2.0?
+title: Why ROS 2?
 permalink: articles/why_ros2.html
 abstract:
   This article captures the reasons for making breaking changes to the ROS API, hence the 2.0.
@@ -83,16 +83,16 @@ We can benefit tremendously from this approach in many ways, including:
 
 ## API changes
 
-A further reason to build ROS 2.0 is to take advantage of the opportunity to improve our user-facing APIs.
+A further reason to build ROS 2 is to take advantage of the opportunity to improve our user-facing APIs.
 A great deal of the ROS code that exists today is compatible with the client libraries as far back as the 0.4 "Mango Tango" release from February 2009.
 That's great from the point of view of stability, but it also implies that we're still living with API decisions that were made several years ago, some of which we know now to be not the best.
 
-So, with ROS 2.0, we will design new APIs, incorporating to the best of our ability the collective experience of the community with the first-generation APIs.
-As a result, while the key concepts (distributed processing, anonymous publish/subscribe messaging, RPC with feedback (i.e., actions), language neutrality, system introspectability, etc.) will remain the same, you should not expect ROS 2.0 to be API-compatible with existing ROS code.
+So, with ROS 2, we will design new APIs, incorporating to the best of our ability the collective experience of the community with the first-generation APIs.
+As a result, while the key concepts (distributed processing, anonymous publish/subscribe messaging, RPC with feedback (i.e., actions), language neutrality, system introspectability, etc.) will remain the same, you should not expect ROS 2 to be API-compatible with existing ROS code.
 
-But fear not: there will be mechanisms in place to allow ROS 2.0 code to coexist with existing ROS code.
+But fear not: there will be mechanisms in place to allow ROS 2 code to coexist with existing ROS code.
 At the very least, there will be translation relays that will support run-time interactions between the two systems.
-And it is possible that there will be library shims that will allow existing ROS code to compile/run against ROS 2.0 libraries, with behavior that is qualitatively similar to what is seen today.
+And it is possible that there will be library shims that will allow existing ROS code to compile/run against ROS 2 libraries, with behavior that is qualitatively similar to what is seen today.
 
 ## Why not just enhance ROS 1
 

--- a/articles/020_ros_with_dds.md
+++ b/articles/020_ros_with_dds.md
@@ -34,7 +34,7 @@ Terminology:
 
 ## Why Consider DDS
 
-When exploring options for the next generation communication system of ROS, the initial options were to either improve the ROS 1.x transport or build a new middleware using component libraries such as [ZeroMQ](http://zeromq.org/), Protocol Buffers, and zeroconf (Bonjour/Avahi).
+When exploring options for the next generation communication system of ROS, the initial options were to either improve the ROS 1 transport or build a new middleware using component libraries such as [ZeroMQ](http://zeromq.org/), Protocol Buffers, and zeroconf (Bonjour/Avahi).
 However, in addition to those options, both of which involved us building a middleware from parts or scratch, other end-to-end middlewares were considered.
 During our research, one middleware that stood out was DDS.
 
@@ -162,7 +162,7 @@ It allows direct access to the RTPS protocol settings and features, which is not
 eProsima's implementation also includes a minimum DDS API, IDL support, and automatic code generation and they are open to working with the ROS community to meet their needs.
 
 Given the relatively strong LGPL option and the encouraging but custom license from RTI, it seems that depending on and even distributing DDS as a dependency should be straightforward.
-One of the goals of this proposal would be to make ROS 2.0 DDS vendor agnostic.
+One of the goals of this proposal would be to make ROS 2 DDS vendor agnostic.
 So, just as an example, if the default implementation is Connext, but someone wants to use one of the LGPL options like OpenSplice or FastRTPS, they simply need to recompile the ROS source code with some options flipped and they can use the implementation of their choice.
 
 This is made possible because of the fact that DDS defines an API in its specification.
@@ -183,11 +183,11 @@ Even though this is something which should be taken into consideration when maki
 
 ## ROS Built on DDS
 
-The goal is to make DDS an implementation detail of ROS 2.0.
+The goal is to make DDS an implementation detail of ROS 2.
 This means that all DDS specific APIs and message definitions would need to be hidden.
 DDS provides discovery, message definition, message serialization, and publish-subscribe transport.
 Therefore, DDS would provide discovery, publish-subscribe transport, and at least the underlying message serialization for ROS.
-ROS 2.0 would provide a ROS 1.x like interface on top of DDS which hides much of the complexity of DDS for the majority of ROS users, but then separately provides access to the underlying DDS implementation for users that have extreme use cases or need to integrate with other, existing DDS systems.
+ROS 2 would provide a ROS 1 like interface on top of DDS which hides much of the complexity of DDS for the majority of ROS users, but then separately provides access to the underlying DDS implementation for users that have extreme use cases or need to integrate with other, existing DDS systems.
 
 ![DDS and ROS API Layout](/img/ros_on_dds/api_levels.png)
 *DDS and ROS API Layout*
@@ -210,25 +210,25 @@ DDS also allows for user defined meta data in their discovery system, which will
 ### Publish-Subscribe Transport
 
 The DDSI-RTPS (DDS-Interoperability Real Time Publish Subscribe) protocol would replace ROS's TCPROS and UDPROS wire protocols for publish/subscribe.
-The DDS API provides a few more actors to the typical publish-subscribe pattern of ROS 1.x.
+The DDS API provides a few more actors to the typical publish-subscribe pattern of ROS 1.
 In ROS the concept of a node is most clearly paralleled to a graph participant in DDS.
 A graph participant can have zero to many topics, which are very similar to the concept of topics in ROS, but are represented as separate code objects in DDS, and is neither a subscriber nor a publisher.
 Then, from a DDS topic, DDS subscribers and publishers can be created, but again these are used to represent the subscriber and publisher concepts in DDS, and not to directly read data from or write data to the topic.
 DDS has, in addition to the topics, subscribers, and publishers, the concept of DataReaders and DataWriters which are created with a subscriber or publisher and then specialized to a particular message type before being used to read and write data for a topic.
 These additional layers of abstraction allow DDS to have a high level of configuration, because you can set QoS settings at each level of the publish-subscribe stack, providing the highest granularity of configuration possible.
 Most of these levels of abstractions are not necessary to meet the current needs of ROS.
-Therefore, packaging common workflows under the simpler ROS-like interface (Node, Publisher, and Subscriber) will be one way ROS 2.0 can hide the complexity of DDS, while exposing some of its features.
+Therefore, packaging common workflows under the simpler ROS-like interface (Node, Publisher, and Subscriber) will be one way ROS 2 can hide the complexity of DDS, while exposing some of its features.
 
 ### Efficient Transport Alternatives
 
-In ROS 1.x there was never a standard shared-memory transport because it is negligibly faster than localhost TCP loop-back connections.
-It is possible to get non-trivial performance improvements from carefully doing zero-copy style shared-memory between processes, but anytime a task required faster than localhost TCP in ROS 1.x, nodelets were used.
+In ROS 1 there was never a standard shared-memory transport because it is negligibly faster than localhost TCP loop-back connections.
+It is possible to get non-trivial performance improvements from carefully doing zero-copy style shared-memory between processes, but anytime a task required faster than localhost TCP in ROS 1, nodelets were used.
 Nodelets allow publishers and subscribers to share data by passing around `boost::shared_ptr`s to messages.
 This intraprocess communication is almost certainly faster than any interprocess communication options and is orthogonal to the discussion of the network publish-subscribe implementation.
 
 In the context of DDS, most vendors will optimize message traffic (even between processes) using shared-memory in a transparent way, only using the wire protocol and UDP sockets when leaving the localhost.
-This provides a considerable performance increase for DDS, whereas it did not for ROS 1.x, because the localhost networking optimization happens at the call to `send`.
-For ROS 1.x the process was: serialize the message into one large buffer, call TCP's `send` on the buffer once.
+This provides a considerable performance increase for DDS, whereas it did not for ROS 1, because the localhost networking optimization happens at the call to `send`.
+For ROS 1 the process was: serialize the message into one large buffer, call TCP's `send` on the buffer once.
 For DDS the process would be more like: serialize the message, break the message into potentially many UDP packets, call UDP's `send` many times.
 In this way sending many UDP datagrams does not benefit from the same speed up as one large TCP `send`.
 Therefore, many DDS vendors will short circuit this process for localhost messages and use a blackboard style shared-memory mechanism to communicate efficiently between processes.
@@ -245,11 +245,11 @@ The point to take away here is that efficient **intra**process communication wil
 There is a great deal of value in the current ROS message definitions.
 The format is simple, and the messages themselves have evolved over years of use by the robotics community.
 Much of the semantic contents of current ROS code is driven by the structure and contents of these messages, so preserving the format and in-memory representation of the messages has a great deal of value.
-In order to meet this goal, and in order to make DDS an implementation detail, ROS 2.0 should preserve the ROS 1.x like message definitions and in-memory representation.
+In order to meet this goal, and in order to make DDS an implementation detail, ROS 2 should preserve the ROS 1 like message definitions and in-memory representation.
 
-Therefore, the ROS 1.x `.msg` files would continue to be used and the `.msg` files would be converted into `.idl` files so that they could be used with the DDS transport.
+Therefore, the ROS 1 `.msg` files would continue to be used and the `.msg` files would be converted into `.idl` files so that they could be used with the DDS transport.
 Language specific files would be generated for both the `.msg` files and the `.idl` files as well as conversion functions for converting between ROS and DDS in-memory instances.
-The ROS 2.0 API would work exclusively with the `.msg` style message objects in memory and would convert them to `.idl` objects before publishing.
+The ROS 2 API would work exclusively with the `.msg` style message objects in memory and would convert them to `.idl` objects before publishing.
 
 ![Message Generation Diagram](/img/ros_on_dds/message_generation.png "Message Generation Diagram")
 
@@ -267,14 +267,14 @@ But this is a different trade-off which can be decided later.
 DDS currently does not have a ratified or implemented standard for request-response style RPC which could be used to implement the concept of services in ROS.
 There is currently an RPC specification being considered for ratification in the OMG DDS working group, and several of the DDS vendors have a draft implementation of the RPC API.
 It is not clear, however, whether this standard will work for actions, but it could at least support non-preemptable version of ROS services.
-ROS 2.0 could either implement services and actions on top of publish-subscribe (this is more feasible in DDS because of their reliable publish-subscribe QoS setting) or it could use the DDS RPC specification once it is finished for services and then build actions on top, again like it is in ROS 1.x.
-Either way actions will be a first class citizen in the ROS 2.0 API and it may be the case that services just become a degenerate case of actions.
+ROS 2 could either implement services and actions on top of publish-subscribe (this is more feasible in DDS because of their reliable publish-subscribe QoS setting) or it could use the DDS RPC specification once it is finished for services and then build actions on top, again like it is in ROS 1.
+Either way actions will be a first class citizen in the ROS 2 API and it may be the case that services just become a degenerate case of actions.
 
 ### Language Support
 
 DDS vendors typically provide at least C, C++, and Java implementations since APIs for those languages are explicitly defined by the DDS specification.
 There are not any well established versions of DDS for Python that research has uncovered.
-Therefore, one goal of the ROS 2.0 system will be to provide a first-class, feature complete C API.
+Therefore, one goal of the ROS 2 system will be to provide a first-class, feature complete C API.
 This will allow bindings for other languages to be made more easily and to enable more consistent behavior between client libraries, since they will use the same implementation.
 Languages like Python, Ruby, and Lisp can wrap the C API in a thin, language idiomatic implementation.
 
@@ -286,7 +286,7 @@ However, writing the entire system in C might not be the first goal, and in the 
 
 ### DDS as a Dependency
 
-One of the goals of ROS 2.0 is to reuse as much code as possible ("do not reinvent the wheel") but also minimize the number of dependencies to improve portability and to keep the build dependency list lean.
+One of the goals of ROS 2 is to reuse as much code as possible ("do not reinvent the wheel") but also minimize the number of dependencies to improve portability and to keep the build dependency list lean.
 These two goals are sometimes at odds, since it is often the choice between implementing something internally or relying on an outside source (dependency) for the implementation.
 
 This is a point where the DDS implementations shine, because two of the three DDS vendors under evaluation build on Linux, OS X, Windows, and other more exotic systems with no external dependencies.
@@ -299,7 +299,7 @@ Additionally, since the goal is to make DDS an implementation detail, it can pro
 
 Following the research into the feasibility of ROS on DDS, several questions were left, including but not limited to:
 
-- Can the ROS 1.x API and behavior be implemented on top of DDS?
+- Can the ROS 1 API and behavior be implemented on top of DDS?
 - Is it practical to generate IDL messages from ROS MSG messages and use them with DDS?
 - How hard is it to package (as a dependency) DDS implementations?
 - Does the DDS API specification actually make DDS vendor portability a reality?
@@ -313,7 +313,7 @@ More questions and some of the results were captured as issues:
 
 [https://github.com/osrf/ros_dds/issues?labels=task&page=1&state=closed](https://github.com/osrf/ros_dds/issues?labels=task&page=1&state=closed)
 
-The major piece of work in this repository is in the `prototype` folder and is a ROS 1.x like implementation of the Node, Publisher, and Subscriber API using DDS:
+The major piece of work in this repository is in the `prototype` folder and is a ROS 1 like implementation of the Node, Publisher, and Subscriber API using DDS:
 
 [https://github.com/osrf/ros_dds/tree/master/prototype](https://github.com/osrf/ros_dds/tree/master/prototype)
 
@@ -328,7 +328,7 @@ Specifically this prototype includes these packages:
 - Talker and listener for pub-sub and service calls: [https://github.com/osrf/ros_dds/tree/master/prototype/src/rclcpp_examples](https://github.com/osrf/ros_dds/tree/master/prototype/src/rclcpp_examples)
 
 - A branch of `ros_tutorials` in which `turtlesim` has been modified to build against the `rclcpp` library: [https://github.com/ros/ros_tutorials/tree/ros_dds/turtlesim](https://github.com/ros/ros_tutorials/tree/ros_dds/turtlesim).
-  This branch of `turtlesim` is not feature-complete (e.g., services and parameters are not supported), but the basics work, and it demonstrates that the changes required to transition from ROS 1.x `roscpp` to the prototype of ROS 2.0 `rclcpp` are not dramatic.
+  This branch of `turtlesim` is not feature-complete (e.g., services and parameters are not supported), but the basics work, and it demonstrates that the changes required to transition from ROS 1 `roscpp` to the prototype of ROS 2 `rclcpp` are not dramatic.
 
 This is a rapid prototype which was used to answer questions, so it is not representative of the final product or polished at all.
 Work on certain features was stopped cold once key questions had been answered.

--- a/articles/030_ros_with_zeromq.md
+++ b/articles/030_ros_with_zeromq.md
@@ -33,7 +33,7 @@ Then the middleware needs to provide one or more transport paradigms for moving 
 Additional communication patterns (such as request-response) can be implemented on top of publish-subscribe.
 Finally, the middleware should provide a means of defining messages and then preparing them for transport, i.e. serialization.
 However, if the middleware lacks a serialization mechanism, this can be provided by an external component.
-Since ROS 1.x was designed, there have been several new libraries in these component fields to gain popularity.
+Since ROS 1 was designed, there have been several new libraries in these component fields to gain popularity.
 
 ### Discovery
 
@@ -86,8 +86,8 @@ Additionally, ZeroMQ, in particular, relies on reliable transports like TCP or [
 
 ### Message Serialization
 
-In ROS 1.x, messages are defined in `.msg` files and code is generated at build time for each of the supported languages.
-ROS 1.x generated code can instantiate and then later serialize the data in a message as a mechanism for exchanging information.
+In ROS 1, messages are defined in `.msg` files and code is generated at build time for each of the supported languages.
+ROS 1 generated code can instantiate and then later serialize the data in a message as a mechanism for exchanging information.
 Since ROS was created, several popular libraries which take care of this responsibility have come about.
 Google's [Protocol Buffers (Protobuf)](https://code.google.com/p/protobuf/), [MessagePack](http://msgpack.org/), [BSON](http://bsonspec.org/), and [Cap'n Proto](http://kentonv.github.io/capnproto/) are all examples of serialization libraries which have come to popularity since ROS was originally written.
 An entire article could be devoted to the pros and cons of different message definition formats, serialization libraries, and their wire formats, but for the purposes of this prototype we worked with either plain strings or Protobuf.
@@ -109,6 +109,6 @@ Even though it would be a lot of work to implement a middleware using component 
 This path would most likely give the most control over the middleware to the ROS community.
 
 In exchange for the creative control over the middleware comes the responsibility to document its behavior and design to the point that it can be verified and reproduced.
-This is a non-trivial task which ROS 1.x did not do very well because it had a relatively good pair of reference implementations.
+This is a non-trivial task which ROS 1 did not do very well because it had a relatively good pair of reference implementations.
 Many users that wish to put ROS into mission critical situations and into commercial products have lamented that ROS lacks this sort of governing design document which allows them to certify and audit the system.
 It would be of paramount importance that this new middleware be well defined, which is not a trivial task and almost certainly rivals the engineering cost of the initial implementation.

--- a/articles/050_ros_rpc_design.md
+++ b/articles/050_ros_rpc_design.md
@@ -32,7 +32,7 @@ ROS Services are basic request-response style RPCs, while ROS Actions additional
 
 ## Ideal System
 
-It is useful to consider the ideal system to understand how it relates to the current ROS 1.x system and how a new system could work.
+It is useful to consider the ideal system to understand how it relates to the current ROS 1 system and how a new system could work.
 An ideal RPC system would have the qualities laid out in the following paragraphs.
 
 ### Asynchronous API
@@ -61,11 +61,11 @@ Feedback is also central to the concept of Actions in ROS.
 
 It is important that the system cannot get into an undetermined state if there is packet loss.
 If a request or response is never received by either side the system must be able to notice this loss, then recover and/or inform the user in some way.
-In ROS 1.x, this lack of reliability has been a problem for ROS Actions, e.g., when they are used over lossy wireless links.
+In ROS 1, this lack of reliability has been a problem for ROS Actions, e.g., when they are used over lossy wireless links.
 
 ### Logging and Introspection
 
-When logging a ROS 1.x system (e.g., using `rosbag`), recording data transmitted on topics is insufficient to capture any information about service calls.
+When logging a ROS 1 system (e.g., using `rosbag`), recording data transmitted on topics is insufficient to capture any information about service calls.
 Because service calls are conceptually point to point, rather than broadcast, logging them is difficult.
 Still, it should be possible to efficiently record some level of detail regarding RPC interactions, such that they could be later played back in some manner (though it is not clear exactly how playback would work).
 

--- a/articles/055_ros_parameter_design.md
+++ b/articles/055_ros_parameter_design.md
@@ -3,7 +3,7 @@ layout: default
 title: Parameter API design in ROS
 permalink: articles/ros_parameters.html
 abstract:
-  This article is proposed design for the interfaces for interacting with parameters in ROS 2.0.
+  This article is proposed design for the interfaces for interacting with parameters in ROS 2.
   We focus here on specifying the system design and leave the implementation unspecified.
 author: '[Tully Foote](https://github.com/tfoote)'
 published: true
@@ -30,7 +30,7 @@ It provided a service based interface to interact with parameters of other nodes
 
 ### Other resources
 
-Other resources related to the parameter design process for ROS 2.0 include:
+Other resources related to the parameter design process for ROS 2 include:
 
 - Gonzalo's research on parameters.
 
@@ -90,7 +90,7 @@ Based on that criteria an ideal system would be able to:
 
 ## Proposed Approach
 
-To cover the feature set above, the ROS 2.0 parameter system is proposed as follows.
+To cover the feature set above, the ROS 2 parameter system is proposed as follows.
 
 ### Parameters Hosted in Nodes
 

--- a/articles/120_realtime_background.md
+++ b/articles/120_realtime_background.md
@@ -22,7 +22,7 @@ It also lays out options for how ROS 2 could be structured to enforce real-time 
 
 Robotic systems need to be responsive.
 In mission critical applications, a delay of less than a millisecond in the system can cause a catastrophic failure.
-For ROS 2.0 to capture the needs of the robotics community, the core software components must not interfere with the requirements of real-time computing.
+For ROS 2 to capture the needs of the robotics community, the core software components must not interfere with the requirements of real-time computing.
 
 ## Definition of Real-time Computing
 

--- a/articles/qos.md
+++ b/articles/qos.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: ROS 2.0 Quality of Service policies
+title: ROS 2 Quality of Service policies
 permalink: articles/qos.html
 abstract:
-  This article describes the approach to provide QoS (Quality of Service) policies for ROS 2.0.
+  This article describes the approach to provide QoS (Quality of Service) policies for ROS 2.
 published: true
 author: '[Esteve Fernandez](https://github.com/esteve)'
 ---
@@ -27,8 +27,8 @@ With the advent of inexpensive robots using unreliable wireless networks, develo
 
 ## Background
 
-ROS 1.x uses TCP as the underlying transport, which is unsuitable for lossy networks such as wireless links.
-With ROS 2.0 relying on DDS which uses UDP as its transport, we can give control over the level of reliability a node can expect and act accordingly.
+ROS 1 uses TCP as the underlying transport, which is unsuitable for lossy networks such as wireless links.
+With ROS 2 relying on DDS which uses UDP as its transport, we can give control over the level of reliability a node can expect and act accordingly.
 
 ## DDS Quality of Service policies
 
@@ -36,9 +36,9 @@ DDS provides fine-grained control over the Quality of Service (QoS) setting for 
 Common entities whose behavior can be modified via QoS settings include: Topic, DataReader, DataWriter, Publisher and Subscriber.
 QoS is enforced based on a Request vs Offerer Model, however Publications and Subscriptions will only match if the QoS settings are compatible.
 
-## ROS 2.0 proposal
+## ROS 2 proposal
 
-Given the complexity of choosing the correct QoS settings for a given scenario, it may make sense for ROS 2.0 to provide a set of predefined QoS profiles for common usecases (e.g. sensor data, real time, etc.), while at the same time give the flexibility to control specific features of the QoS policies for the most common entities.
+Given the complexity of choosing the correct QoS settings for a given scenario, it may make sense for ROS 2 to provide a set of predefined QoS profiles for common usecases (e.g. sensor data, real time, etc.), while at the same time give the flexibility to control specific features of the QoS policies for the most common entities.
 
 ## QoS profiles
 
@@ -68,12 +68,12 @@ The base QoS profile includes settings for the following policies:
 
 Note: for each of the main bullets there is also the option of "system default", which uses whatever setting was defined via the DDS vendor tools (e.g. XML configuration files).
 
-ROS 2.0 will provide QoS profiles based on the following use cases:
+ROS 2 will provide QoS profiles based on the following use cases:
 
 - Default QoS settings for publishers and subscriptions
 
-  In order to make the transition from ROS1 to ROS2, exercising a similar network behavior is desirable.
-  By default, publishers and subscriptions are reliable in ROS2, have volatile durability, and "keep last" history.
+  In order to make the transition from ROS 1 to ROS 2, exercising a similar network behavior is desirable.
+  By default, publishers and subscriptions are reliable in ROS 2, have volatile durability, and "keep last" history.
 
 - Services
 
@@ -98,10 +98,10 @@ Note: the values in the profiles are subject to further tweaks, based on the fee
 ## Integration with existing DDS deployments
 
 Both PrismTech OpenSplice and RTI Connext support loading of QoS policies via an external XML file.
-In environments where DDS is already deployed and also to enable more extensibility other than the offered by the ROS 2.0 and the predefined profiles, ROS 2.0 may provide loading of the QoS settings via the same mechanisms the underlying DDS implementations use.
-However, this mechanism will not be added into the common ROS2 API so as to keep the `rmw` layer transport agnostic and let future developers implement it for other transports (e.g. ZeroMQ, TCPROS, etc.)
+In environments where DDS is already deployed and also to enable more extensibility other than the offered by the ROS 2 and the predefined profiles, ROS 2 may provide loading of the QoS settings via the same mechanisms the underlying DDS implementations use.
+However, this mechanism will not be added into the common ROS 2 API so as to keep the `rmw` layer transport agnostic and let future developers implement it for other transports (e.g. ZeroMQ, TCPROS, etc.)
 To honor the QoS settings of the system, developers can use the `rmw_qos_profile_system_default` QoS profile which delegates the responsibility of the QoS machinery to the underlying DDS vendor.
-This allows developers to deploy ROS2 applications and use DDS vendor tools to configure the QoS settings.
+This allows developers to deploy ROS 2 applications and use DDS vendor tools to configure the QoS settings.
 
 ## Integration with non DDS RMW Implementations
 

--- a/articles/ros2_threat_model.md
+++ b/articles/ros2_threat_model.md
@@ -95,7 +95,7 @@ This is a **DRAFT DOCUMENT**.
     - [Threat Model](#threat-model)
       - [Attack Trees](#attack-trees)
       - [Physical vector attack tree](#physical-vector-attack-tree)
-      - [ROS2 API vector attack tree](#ros2-api-vector-attack-tree)
+      - [ROS 2 API vector attack tree](#ros2-api-vector-attack-tree)
       - [H-ROS API vector attack tree](#h-ros-api-vector-attack-tree)
       - [Code repository compromise vector attack tree](#code-repository-compromise-vector-attack-tree)
     - [Threat Model Validation Strategy](#threat-model-validation-strategy-1)
@@ -3541,7 +3541,7 @@ to be evaluated.
 ## Threat Analysis for the `MARA` Robotic Platform
 
 ### System description
-The application considered in this section is a **[MARA][mara_robot] modular robot operating on an industrial environment while performing a pick & place activity**. MARA is the first robot to run ROS 2 natively. It is an industrial-grade collaborative robotic arm which runs ROS 2.0 on each joint, end-effector, external sensor or even on its industrial controller. Throughout the H-ROS communication bus, MARA is empowered with new possibilities  in the professional landscape of robotics. It offers millisecond-level distributed bounded latencies for usual payloads and submicrosecond-level synchronization capabilities across ROS 2 components.
+The application considered in this section is a **[MARA][mara_robot] modular robot operating on an industrial environment while performing a pick & place activity**. MARA is the first robot to run ROS 2 natively. It is an industrial-grade collaborative robotic arm which runs ROS 2 on each joint, end-effector, external sensor or even on its industrial controller. Throughout the H-ROS communication bus, MARA is empowered with new possibilities  in the professional landscape of robotics. It offers millisecond-level distributed bounded latencies for usual payloads and submicrosecond-level synchronization capabilities across ROS 2 components.
 
 Built out of individual modules that natively run on ROS 2, MARA can be physically extended in a seamless manner. However, this also moves towards more networked robots and production environments which brings new challenges, especially in terms of [security and safety][safe_sec].
 
@@ -3646,7 +3646,7 @@ This section aims for describing the components and specifications within the MA
         * Middleware: Data Distribution Service (DDS)
       * On-board computation: Dual core ARM® Cortex-A9
       * Operating System: Real-Time Linux
-      * ROS 2.0 version: Crystal Clemmys
+      * ROS 2 version: Crystal Clemmys
       * Information model: [HRIM][hrim] Coliza
       * Security:
         * DDS crypto, authentication and access control plugins
@@ -3658,7 +3658,7 @@ This section aims for describing the components and specifications within the MA
         * Middleware: Data Distribution Service (DDS)
       * On-board computation: Dual core ARM® Cortex-A9
       * Operating System: Real-Time Linux
-      * ROS 2.0 version: Crystal Clemmys
+      * ROS 2 version: Crystal Clemmys
       * Information model: [HRIM][hrim] Coliza
       * Security:
         * DDS crypto, authentication and access control plugins
@@ -3670,7 +3670,7 @@ This section aims for describing the components and specifications within the MA
     * Link layer: 2 x Gigabit (1 Gbps) TSN Ethernet network interface
     * Middleware: Data Distribution Service (DDS)
   * Operating System: Real-Time Linux
-  * ROS 2.0 version: Crystal Clemmys
+  * ROS 2 version: Crystal Clemmys
   * Information model: [HRIM][hrim] Coliza
   * Security:
     * DDS crypto, authentication and access control plugins
@@ -3708,7 +3708,7 @@ In this section all the processes running on the robotic system in scope are det
   * MoveIt! motion planning framework.
   * Manufacturing process control applications.
   * Robot teleoperation utilities.
-  * **ROS1/ROS2 bridges**: These bridges are needed to be able to run MoveIT! which is not yet ported to ROS 2.0. Right now there is an [effort in the community](https://acutronicrobotics.com/news/ros-2-moveit-robotic-motion-planning/) to port this tool to ROS 2.0.
+  * **ROS 1 / ROS 2 bridges**: These bridges are needed to be able to run MoveIT! which is not yet ported to ROS 2. Right now there is an [effort in the community](https://acutronicrobotics.com/news/ros-2-moveit-robotic-motion-planning/) to port this tool to ROS 2.
 
 ##### Software dependencies
 
@@ -3808,7 +3808,7 @@ As described above, the application considered is a MARA modular robot operating
     * Development of new functionality and improvements for the MARA robot.
       * Develop new software for the H-ROS SoM
       * Update OS and system libraries
-      * Update ROS2 subsystem and control nodes
+      * Update ROS 2 subsystem and control nodes
       * Deployment of new updates to the robots and management of the fleet
       * In-Place robot maintenance
 
@@ -4646,17 +4646,17 @@ The next diagram shows the infrastructure affected on a possible attack based on
 
 ![Physical vector attack architecture](ros2_threat_model/attack_tree_physical_arch.png)
 
-#### ROS2 API vector attack tree
+#### ROS 2 API vector attack tree
 
 The following attack tree describes the possible paths to be followed by an attacker for  physically compromising the system.
 
-![ROS2 API vector attack tree](ros2_threat_model/attack_tree_ros2.png)
+![ROS 2 API vector attack tree](ros2_threat_model/attack_tree_ros2.png)
 
 [Diagram Source (draw.io)](ros2_threat_model/attack_tree_ros2.xml)
 
-The following diagram shows the infrastructure affected on a possible attack based on exploitation of the ROS2 API.
+The following diagram shows the infrastructure affected on a possible attack based on exploitation of the ROS 2 API.
 
-![ROS2 API vector attack architecture](ros2_threat_model/attack_tree_ros2_arch.png)
+![ROS 2 API vector attack architecture](ros2_threat_model/attack_tree_ros2_arch.png)
 
 #### H-ROS API vector attack tree
 

--- a/articles/serialization.md
+++ b/articles/serialization.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: ROS 2.0 Message Research
+title: ROS 2 Message Research
 abstract:
-  This article captures the research done in regards to the serialization component, including an overview of the current implementation in ROS 1.x and the alternatives for ROS 2.0.
+  This article captures the research done in regards to the serialization component, including an overview of the current implementation in ROS 1 and the alternatives for ROS 2.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas) and [Esteve Fernandez](https://github.com/esteve)'
 ---
@@ -31,7 +31,7 @@ So a very important goal is to make the message interface flexible enough to be 
 
 ## Existing Implementations
 
-ROS 1.x messages are data objects which use member-based access to the message fields.
+ROS 1 messages are data objects which use member-based access to the message fields.
 While the message specification is not very feature rich the serializer is pretty fast.
 The ROS distribution contains message serializers implemented in C++, Python and Lisp.
 Besides that the community provided implementations for other languages, like C, Ruby, MatLab, etc.
@@ -68,7 +68,7 @@ Since this use case implies severe constraints that are not optimal for scenario
 
 #### Optional fields, default values
 
-In ROS 1.x, messages and services require all data members and arguments to be specified.
+In ROS 1, messages and services require all data members and arguments to be specified.
 By using optional fields and default values, we can define simpler APIs so that users\' code can be more succinct and more readable.
 At the same time we could also provide sane values for certain APIs, such as for sensors.
 

--- a/contribute.md
+++ b/contribute.md
@@ -6,7 +6,7 @@ show_in_nav: true
 
 # Contribute
 
-There are many ways you can contribute to the ROS 2.0 design effort.
+There are many ways you can contribute to the ROS 2 design effort.
 The most important of which is probably to review the list of articles posted on the [home page](/) and familiarize yourself with the discussions surrounding an issue before getting involved.
 This will help keep everyone on the same page and prevent having to discuss things multiple times.
 

--- a/index.md
+++ b/index.md
@@ -10,20 +10,20 @@ category_order:
   - Security
 ---
 
-# ROS 2.0 Design
+# ROS 2 Design
 
-This site is repository of articles which are designed to inform and guide the ROS 2.0 design efforts.
-The goal of [the ROS 2.0 project](https://github.com/ros2/ros2/wiki) is to leverage what is great about ROS 1.x and improve what isn't.
+This site is repository of articles which are designed to inform and guide the ROS 2 design efforts.
+The goal of [the ROS 2 project](https://github.com/ros2/ros2/wiki) is to leverage what is great about ROS 1 and improve what isn't.
 
 If you would like to contribute to this site, checkout the [contribute](/contribute.html) page to learn how.
-If you would like to contribute to the ROS 2.0 project, see [this page](https://github.com/ros2/ros2/wiki/Contributing) for more details.
+If you would like to contribute to the ROS 2 project, see [this page](https://github.com/ros2/ros2/wiki/Contributing) for more details.
 
 The best mailing list for discussing these topics is [ros-sig-ng-ros@googlegroups.com](mailto:ros-sig-ng-ros@googlegroups.com), the Special Interest Group on Next-Generation ROS mailing list.
 You can view the archives [here](https://groups.google.com/forum/?fromgroups#!forum/ros-sig-ng-ros).
 
 # Articles
 
-Here is a list of the articles (white papers) which have been written so far. These articles should serve as an entry point for anyone wanting to join the conversation about a variety of the topics that relate to ROS 2.0.
+Here is a list of the articles (white papers) which have been written so far. These articles should serve as an entry point for anyone wanting to join the conversation about a variety of the topics that relate to ROS 2.
 
 {% assign sorted_pages = site.pages | sort:"name" %}
 


### PR DESCRIPTION
The guideline for referring to specific major version of ROS should be:
* a space between "ROS" and the major version "1" or "2"
* no minor version like "2.0" or "1.x"

This patch changes various variations to follow that guideline.

* Before: `ROS2`, `ROS 2.0`, `ROS 1.x`
* After: `ROS 1`, `ROS 2`