### PR TITLE
Reconsider Node to Participant mapping

### DIFF
--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Node to Participant mapping
-permalink: articles/node_to_participant_mapping.html
-abstract: This article analyzes the performance implications of enforcings a one-to-one mapping between ROS nodes and DDS participants, and proposes alternative approaches.
+permalink: articles/Node_to_Participant_mapping.html
+abstract: This article analyzes the performance implications of enforcing a one-to-one mapping between ROS Nodes and DDS Participants, and proposes alternative implementation approaches.
 author: '[Ivan Paunovic](https://github.com/ivanpauno)'
 published: true
 categories: Middleware
@@ -20,96 +20,97 @@ Original Author: {{ page.author }}
 
 ## Background
 
-### `Node`
+### Node
 
-In ROS, a `Node` is an entity used to group other entities.
-For example: `Publishers`, `Subscriptions`, `Services`, `Clients`.
-`Nodes` ease organization and code reuse, as they can be composed in different ways.
+In ROS, a Node is an entity used to group other entities.
+For example: Publishers, Subscriptions, Servers, Clients.
+Nodes ease organization and code reuse, as they can be composed in different ways.
 
-### `Domain Participant`
+### Domain Participant
 
-A `Domain Participant` is a type of DDS entity.
-`Participants` also group other entities, like `Publishers`, `Subscribers`, `Data Writters`, `Data Readers`, etc.
-Creating more `Participants` adds overhead to an application:
+A Participant is a type of DDS entity.
+Participant also group other entities, like Publishers, Subscribers, Data Writters, Data Readers, etc.
+Creating more Participants adds overhead to an application:
 
-- Each `Participant` participates in discovery.
-  Creating more than one `Participant` increases cpu usage and network IO load.
-- Each `Participant` keeps track of other `Domain Participants` and DDS entities.
-  Using more than one will duplicate that data within a single process.
-- Each `Participant` may create multiple threads for event handling, discovery, etc.
-  The number of threads created per participant depend on the DDS vendor (e.g.: [connext](https://community.rti.com/best-practices/create-few-domainparticipants-possible)).
+- Each Participant participates in discovery.
+  Creating more than one Participant usually increases CPU usage and network IO load.
+- Each Participant keeps track of other DDS entities.
+  Using more than one within a single process will result in data duplication.
+- Each Participant may create multiple threads for event handling, discovery, etc.
+  The number of threads created per Participant depend on the DDS vendor (e.g.: [RTI Connext](https://community.rti.com/best-practices/create-few-domainParticipants-possible)).
 
-For those reasons, `Participants` are a heavyweight entity.
+For those reasons, a Participant is a heavyweight entity.
 
-Note: This might actually depend on the DDS implementation, some of them share these resources between `Participants` (e.g. OpenSplice).
-Many `DDS` vendors don't do this (e.g.: `rti Connext` and `Fast-RTPS`), and they actually recommend creating just one `Participant` per process.
+Note: This might actually depend on the DDS implementation, some of them share these resources between Participants (e.g. OpenSplice).
+Many DDS vendors, however, do not perform this kind of optimization (e.g.: `RTI Connext` and `Fast-RTPS`), and actually recommend creating just one Participant per process.
 
-### `Context`
+### Context
 
-In ROS, a `Context` is the no-global state of an init-shutdown cycle.
-It also encapsulates shared state between nodes and other entities.
-In most applications, there is only one `ROS Context` in a process.
+In ROS, a Context is the non-global state of an init-shutdown cycle.
+It also encapsulates shared state between Nodes and other entities.
+In most applications, there is only one ROS Context in a process.
 
-## Current status
+## Behavior pre-Foxy
 
-There is a one-to-one mapping between `Nodes` and `DDS Participants`.
-This simplified the original implementation, as `DDS Participants` provide many features equivalent to the ones of a `ROS Node`.
-The drawback of this approach is the overhead originated by creating many participants.
-Furthermore, the maximum number of `Domain participants` is rather small.
-For example, [RTI connext](https://community.rti.com/kb/what-maximum-number-participants-domain) is limited to 120 participants per domain.
+There is a one-to-one mapping between Nodes and DDS Participants.
+This simplified the original implementation, as DDS Participants provide many features equivalent to the ones of ROS Nodes.
+The drawback of this approach is the overhead that comes with creating many Participants.
+Furthermore, the maximum number of Domain Participants is rather small.
+For example, in [RTI Connext](https://community.rti.com/kb/what-maximum-number-Participants-domain) it is limited to 120 Participants per Domain.
 
 ## Proposed approach
 
-The goal of this proposal is to improve overall performance by avoiding the creation of one `Domain Participant` per `Node`.
+The goal of this proposal is to improve overall performance by avoiding the creation of one Participant per Node.
 API changes will be avoided, if possible.
 
-### Mapping of `DDS Participant` to a `ROS` entity
+### Mapping of DDS Participant to a ROS entity
 
-There are two alternatives, besides the current `Node` to `Participant` mapping:
-- Using one participant per process.
-- Using one participant per context.
+There are two alternatives, besides the one-to-one Node to Participant mapping used pre-Foxy:
+- Using one Participant per process.
+- Using one Participant per Context.
 
-The second approach allows more flexibility, and it will allow creating more than one `Participant` for applications that need it --e.g. domain bridge applications--.
-Thus, a one to one `Participant` to `Context` mapping was chosen.
+The second approach allows more flexibility, and it will allow creating more than one Participant for applications that need it e.g. domain bridge applications.
+Thus, a one-to-one Participant to Context mapping was chosen.
 
-In the case where multiple nodes are running in a single process, we have different options for grouping them by - ranging from a separate context for each node, over grouping a few nodes in the same context, to using a single context for all nodes.
-For most applications, only one `Context` is created.
+When the case where multiple Nodes are running in a single process, there are different options for grouping them by - ranging from a separate context for each Node, over grouping a few Nodes in the same context, to using a single context for all Nodes.
+For most applications, only one Context is created.
 
 ### Discovery information
 
-When not using a one to one `Node`/`Participant` mapping, extra discovery information is needed to be able to match other entities to a `Node` --e.g. publishers, subscriptions, etc--.
-Several approaches can be used to share this information, the proposed approach uses a topic for it.
-Each `Participant` publishes a message with all the information needed to match an entity to a `Node`.
-The message definition is the following:
+If a one-to-one Node to Participant mapping is not used, extra discovery information is needed to be able to match other entities to a Node e.g. Publishers, Subscriptions, etc.
+Several approaches can be used to share this information.
+The proposed approach uses a topic for it.
+Each Participant publishes a message with all the information needed to match an entity to a Node.
+The message structure is the following:
 
 * ParticipantInfo
   * gid
   * NodeInfo
-    * node namespace
-    * node name
-    * reader gid
+    * Node namespace
+    * Node name
+    * Reader gid
     * writed gid
 
-When one entity is updated --e.g.: A `Publisher` is created or destroyed--, a new message is sent.
+When one entity is updated (e.g.: a Publisher is created or destroyed), a new message is sent.
 
-Identification of `Clients` and `Services` happens according to the ros conventions for their topic names (see [	
+Identification of Clients and Servers happens according to the ROS conventions for their topic names (see [	
 Topic and Service name mapping to DDS](140_topic_and_service_name_mapping.md)).
 
 This topic is considered an implementation detail, and not all `rmw` implementations have to use it.
-Thus, all the necessary logic has to be in the rmw implementation itself or in a downstream package.
+Thus, all the necessary logic has to be in the rmw implementation itself or in an upstream package.
 Implementing this logic in `rcl` would make it part of the API, and not an implementation detail.
 
 To avoid code repetition, a common implementation of the logic was done in [rmw_dds_common](https://github.com/ros2/rmw_dds_common/).
 
-#### Details of the ros discovery topic
+#### Details of the ROS discovery topic
 
 - topic name: `ros_discovery_info`
-- writer qos:
+- Writer qos:
   - durability: transient local
   - history: keep last
   - history depth: 1
   - reliability: reliable
-- reader qos:
+- Reader qos:
   - durability: transient local
   - history: keep all
   - history depth: 1
@@ -119,37 +120,41 @@ To avoid code repetition, a common implementation of the logic was done in [rmw_
 
 #### Security
 
-Previously, each node could have different security artifacts.
-That was possible because each node was mapped to one `Participant`.
+Previously, each Node could have different security artifacts.
+That was possible because each Node was mapped to one Participant.
 The new approach allows to specify different security artifacts for each process.
 For more details, see [ROS 2 Security Enclaves](ros2_security_enclaves.md).
 
 #### Ignore local publications option
 
-There's an `ignore_local_publications` option that can be set when [creating a subscription](https://github.com/ros2/rmw/blob/2250b3eee645d90f9e9d6c96d71ce3aada9944f3/rmw/include/rmw/rmw.h#L517).
-That option avoids receiving messages from `Publishers` within the same `Node`.
-This wasn't implemented in all the rmw implementations (e.g.: [FastRTPS](https://github.com/ros2/rmw_fastrtps/blob/099f9eed9a0f581447405fbd877c6d3b15f1f26e/rmw_fastrtps_cpp/src/rmw_subscription.cpp#L118)).
+There is an `ignore_local_publications` option that can be set when [creating a Subscription](https://github.com/ros2/rmw/blob/2250b3eee645d90f9e9d6c96d71ce3aada9944f3/rmw/include/rmw/rmw.h#L517).
+That option avoids receiving messages from Publishers within the same Node.
+This wasn't implemented in all the rmw implementations (e.g.: [FastRTPS](https://github.com/ros2/rmw_fastrtps/blob/099f9eed9a0f581447405fbd877c6d3b15f1f26e/rmw_fastrtps_cpp/src/rmw_Subscription.cpp#L118)).
 
 After this change, implementing this feature will be less direct.
-Some extra logic needs to be added in order to identify from which `Node` a `Publisher` was created.
+Some extra logic needs to be added in order to identify from which Node a Publisher was created.
 
 ## Alternative implementations
 
 ### Using keyed topics
 
-Keyed topics could be used, with the participant gid as the key.
-That would allow the reader side of the topic to use a keep last, depth 1 history.
+Keyed topics could be used, with the Participant gid as the key.
+That would allow the Reader side of the topic to use a keep last, depth 1 history.
 
-### Using participant/writer/reader user data
+### Using Participant/Writer/Reader userData QoS
 
-Instead of using a custom topic to share the extra ROS specific discovery information, a combination of participant/reader/writer user data could be used.
-e.g.:
+Instead of using a custom topic to share the extra ROS specific discovery information, a combination of Participant/Reader/Writer `userData` could be used:
 
-- Participant user data: list of nodes created by the participant (updated when node created destroyed).
-- Reader user data: node name/namespace.
-- Writer user data: node name/namespace.
+- Participant `userData`: list of Nodes created by the Participant (updated when Node created destroyed).
+- Reader user `userData`: Node name/namespace.
+- Writer user `userData`: Node name/namespace.
 
-That information would be enough to satisfy ros2 required graph API.
-This mechanism will also avoid to have a topic where all nodes need to have write and read access.
+That information would be enough to satisfy ROS 2 required graph API.
+This mechanism would also preclude having a topic that has to be read and written by all Nodes, which is better from a security perspective.
 
 This alternative wasn't implemented because of lack of support in some of the currently supported DDS vendors.
+
+## Further work
+
+This optimization has been applied to `rmw_cyclonedds`, `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`.
+Other DDS based `rmw` implementations, like `rmw_connext_cpp` could use the same approach.

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -146,6 +146,29 @@ These entities only need to communicate the GUID of the `Participant` and the `N
 This idea can be combined with a topic just publishing the list of `Node` names, without including all the other vectors in the message.
 Although, it is more difficult to communicate this information for `Services` and `Clients`, as they use behind the scenes just a `DDS Publisher` and `Subscriber`.
 
+### Which layer will be implemented in?
+
+The implementation can be done in two different ways:
+
+- Through rmw implementations to rcl.
+- Modify rmw implementations without modifying rmw API (as long as possible).
+
+The first approach have the following disadvantages:
+- There is no `Node` concept in `rmw` layer, as `Node` discovery is solved in `rcl`.
+  Actually, all the `Node` related API in `rmw` doesn't have more sense.
+- Currently, no threads are created in the `rcl` layer.
+  It will be needed in case `Node` discovery is done in this layer.
+- It will force to build the concept of `Node` on top of the underlying middleware in use, regardless if the middleware already has a lightweight entity similar to a `Node`.
+- It will break API in many layers.
+
+
+The second approach has the following disadvantages:
+- Each `rmw` have to reimplement node discovery logic.
+  - It can be worked arround creating a new common package that uses the abstractions in `rmw`.
+    Each of the implementations that wants to use this should depend on this common package.
+
+The second approach is preferred, as it is more flexible and it avoids breaking API in many layers.
+
 ### Other implications
 
 #### Security

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -2,7 +2,7 @@
 layout: default
 title: Node to Participant mapping
 permalink: articles/node_to_participant_mapping.html
-abstract: This article analyzes the performance implications of enforcings a one-to-one mapping between ROS nodes and DDS participants, and propose alternative approaches.
+abstract: This article analyzes the performance implications of enforcings a one-to-one mapping between ROS nodes and DDS participants, and proposes alternative approaches.
 author: '[Ivan Paunovic](https://github.com/ivanpauno)'
 published: true
 categories: Middleware
@@ -30,7 +30,7 @@ For example: `Publishers`, `Subscriptions`, `Services`, `Clients`.
 
 A `Domain Participant` is a type of DDS entity.
 `Participants` also group other entities, like `Publishers`, `Subscribers`, `Data Writters`, `Data Readers`, etc.
-But participants do more than that:
+Creating more `Participants` adds overhead to an application:
 
 - Each `Participant` participates in discovery.
   Creating more than one `Participant` increases cpu usage and network IO load.
@@ -39,200 +39,90 @@ But participants do more than that:
 - Each `Participant` may create multiple threads for event handling, discovery, etc.
   The number of threads created per participant depend on the DDS vendor (e.g.: [connext](https://community.rti.com/best-practices/create-few-domainparticipants-possible)).
 
-For those reasons, `Participants` are heavyweight.
+For those reasons, `Participants` are a heavyweight entity.
 
 Note: This might actually depend on the DDS implementation, some of them share these resources between `Participants` (e.g. OpenSplice).
 Many `DDS` vendors don't do this (e.g.: `rti Connext` and `Fast-RTPS`), and they actually recommend creating just one `Participant` per process.
 
 ### `Context`
 
-The `ROS Context` is the no-global state of an init-shutdown cycle.
+In ROS, a `Context` is the no-global state of an init-shutdown cycle.
 It also encapsulates shared state between nodes and other entities.
 In most applications, there is only one `ROS Context` in a process.
 
 ## Current status
 
 There is a one-to-one mapping between `Nodes` and `DDS Participants`.
-This simplified the design, as `DDS Participants` provide the same organization that a `Node` needs.
-The drawback of this approach, is that with an increasing number of nodes the overhead also increases.
+This simplified the original implementation, as `DDS Participants` provide many features equivalent to the ones of a `ROS Node`.
+The drawback of this approach is the overhead originated by creating many participants.
 Furthermore, the maximum number of `Domain participants` is rather small.
 For example, [RTI connext](https://community.rti.com/kb/what-maximum-number-participants-domain) is limited to 120 participants per domain.
 
-## Proposal
+## Proposed approach
 
 The goal of this proposal is to improve overall performance by avoiding the creation of one `Domain Participant` per `Node`.
 API changes will be avoided, if possible.
 
-### Mapping of the `Participant` to a `ROS` entity
+### Mapping of `DDS Participant` to a `ROS` entity
 
-There are two main alternatives, besides the current mapping to a `Node`:
+There are two alternatives, besides the current `Node` to `Participant` mapping:
 - Using one participant per process.
 - Using one participant per context.
 
-The second approach allows more flexibility.
-Considering that by default there's only one context per process, it wouldn't affect the case where each node runs in its own process.
+The second approach allows more flexibility, and it will allow creating more than one `Participant` for applications that need it --e.g. domain bridge applications--.
+Thus, a one to one `Participant` to `Context` mapping was chosen.
+
 In the case where multiple nodes are running in a single process, we have different options for grouping them by - ranging from a separate context for each node, over grouping a few nodes in the same context, to using a single context for all nodes.
+For most applications, only one `Context` is created.
 
-In any of both options, a `Node` stops being a real middleware node, and starts being just a collection of `ROS` entities.
+### Discovery information
 
-### ROS specific discovery information
+When not using a one to one `Node`/`Participant` mapping, extra discovery information is needed to be able to match other entities to a `Node` --e.g. publishers, subscriptions, etc--.
+Several approaches can be used to share this information, the proposed approach uses a topic for it.
+Each `Participant` publishes a message with all the information needed to match an entity to a `Node`.
+The message definition is the following:
 
-#### Using a topic
+* ParticipantInfo
+  * gid
+  * NodeInfo
+    * node namespace
+    * node name
+    * reader gid
+    * writed gid
 
-The name of all the available `Nodes`, and its `Publishers`, `Subscriptions`, `Services`, `Clients` should be available for every `Participant`.
-This information can be communicated using a `topic`.
-That topic will be an implementation detail and hidden to the user (i.e.: the `rt/` prefix won't be added to this `DDS topic`).
+When one entity is updated --e.g.: A `Publisher` is created or destroyed--, a new message is sent.
 
-One message could be sent for each:
-- `Node`
-- `Participant`
+Identification of `Clients` and `Services` happens according to the ros conventions for their topic names (see [	
+Topic and Service name mapping to DDS](140_topic_and_service_name_mapping.md)).
 
-The second option reduces the amount of messages.
-It also allow organizing the data using the `Participant` GUID as the key.
-It's not possible to organize the data using the `Node` name as a key, because it can collide.
-`Node` name uniqueness can be enforced using a collision resolution mechanism, but it can't be detected beforehand.
-In the following, the second option will be considered.
+This topic is considered an implementation detail, and not all `rmw` implementations have to use it.
+Thus, all the necessary logic has to be in the rmw implementation itself or in a downstream package.
+Implementing this logic in `rcl` would make it part of the API, and not an implementation detail.
 
-##### State Message
+To avoid code repetition, a common implementation of the logic was done in [rmw_dds_common](https://github.com/ros2/rmw_dds_common/).
 
-Each `Participant` will send a message representing their state.
-A keyed topic could be used for communicating it.
-The `Participant` GUID can be used as the key.
-This helps for keeping only one message per `Participant` in the history (see [QoS for communicating node information](#QoS-for-communicating-node-information)).
-The rest of the message will be a sequence with information for each node.
-For each `Node`, the message should contain the `Node` name, and four sequences:
-- GUID of its `Publishers`
-- GUID of its `Subscriptions`
-- GUID of its `Services`
-- GUID of its `Clients`
+#### Details of the ros discovery topic
 
-Vector bounds: TBD
+- topic name: `ros_discovery_info`
+- writer qos:
+  - durability: transient local
+  - history: keep last
+  - history depth: 1
+  - reliability: reliable
+- reader qos:
+  - durability: transient local
+  - history: keep all
+  - history depth: 1
+  - reliability: reliable
 
-This state message is sent each time a new `ROS Entity` is created.
-e.g.: A participant will updates its message when a new `Node` is created.
-
-##### QoS for communicating node information
-
-Each published message should be available to late `Subscribers`, and only the last message of each key should be kept.
-For that reason, the QoS of the `Publishers` should be:
-
-- Durability: Transient Local
-- History: Keep Last
-- History depth: 1
-- Reliability: Reliable
-
-If a keyed topic is used, in which the history depth apply for each key, only one `Publisher` per process will be needed.
-The QoS of the `Subscriber` should be:
-
-- Durability: Transient Local
-- History: Keep Last
-- History depth: 1
-- Reliability: Reliable
-
-In case keyed topics aren't used, `keep all` history should be used.
-
-The subscriber could access data in two different ways:
-- Polled and accessed using `Subscriber` read method when needed.
-- Listened, accessed using subscriber take method and organized in a local cache.
-
-The second option allows better organization of this information (e.g.: in hash tables).
-
-#### Using USER_DATA and GROUP_DATA QoSPolicy
-
-Each `Participant` could store in its user data, the list of node names that it owns.
-When this data is changed, each `ParticipantListener` will be notified.
-This is not a good option, as `UserData` is just a sequence of bytes.
-Organizing a complex message in it won't be easy nor performant.
-
-Similarly to `UserData`, `GroupData` is a available in `Publishers` and `Subscribers`.
-These entities only need to communicate the GUID of the `Participant` and the `Node` name from which it was created.
-This idea can be combined with a topic just publishing a list of `Node` names of a `Participant`.
-
-Support for `GroupData` was not available in some of the `DDS-vendors` at the moment of the implementation.
-For that reason this option was discarded.
-
-### Implementation
-
-The implementation can be done in two different ways:
-
-- Implementing the discovery logic in `rcl`.
-- Modifying rmw implementations without modifying rmw API (as long as possible).
-
-The first approach have the following disadvantages:
-- There is no `Node` concept in `rmw` layer, as `Node` discovery is solved in `rcl`.
-  Actually, all the `Node` APIs in `rmw` will not longer make sense.
-- Currently, no threads are created in the `rcl` layer.
-  It will be needed in case `Node` discovery is done in this layer.
-- It will force us to build the concept of `Node` on top of the underlying middleware, regardless if the middleware already has a lightweight entity similar to a `Node`.
-- It will break API in many layers.
-
-
-The second approach has the following disadvantages:
-- Each RMW implementation has to reimplement node discovery logic.
-  This can be avoided by arround creating a new common package that uses the abstractions in `rmw`.
-  Each of the implementations that wants to use this should depend on this common package.
-
-The second approach is preferred, as it is more flexible and it avoids breaking API in many layers.
-
-### Other implications
+## Other implications
 
 #### Security
 
-In `DDS`, security can be specified at a `Participant` level.
-If one `Node` is mapped to one `Participant`, individual configuration of its security key and access control policy is possible.
-From a security point of view, only being able to configure it at a `Participant` (or per process) level should be enough.
-It does not make much sense to have different access control policies for `Nodes` in the same process.
-As they share the same address space, other vulnerabilities are possible.
-
-##### Security directory of each participant
-
-Before, the environment variable `ROS_SECURITY_DIRECTORY` specified the root path of the keystore.
-The security files for each participant were found using the node name from that root.
-
-With this proposal, it won't be possible to find the security files from the node name, as the `Participant` will be associated with a `Context`.
-
-A few alternatives are possible:
-- Add a name to the `Context`, and use the same directory discovery logic.
-- Just be able to pass a directory to each process. All the `Contexts` in a process will use the same security files.
-
-The first alternative is more flexible, as it allows to specify different security files for `Contexts` in the same process.
-That's particuarly useful for some use cases, e.g.: domain bridges.
-
-The `Context` name will be available in ros2 graph API.
-That will allow adapting the tool that generates the policy files from a running example.
-
-The `Context` doesn't pretend to be unique, and it's just a way of specifying configurations.
-Particularly, for specifying the security directory.
-There will be a default context name, so a default security directory can be specified.
-It should be possible to remap this name, to allow easy deployment of nodes.
-
-##### Generating DDS permissions files from ROS policies files
-
-Currently, ROS access control policy files allows specifying privilages to each `Node`.
-From that file, the required DDS permission file is generated.
-
-Considering this proposal, there are a few alternatives:
-- Contexts are added to the policy file.
-- A tool for generating a permission file from multiple ROS policy files is added.
-
-In the first case, the `Context` will work as a way of grouping all the privilages of its nodes.
-That also will work for `rmw` implementations where a `Node` can have separate policy files, in which case the context grouping will just be ignored.
-
-A tool for combining policies files can be added, regardless if the policy file format is changed or not.
-
-#### Node Name Uniqueness
-
-In `Dashing` and before, `Node` name uniqueness is not enfornced.
-
-When creating only one `Participant` per `Context`, we can distinguish two cases:
-- There is an overlap between the name of two `Nodes` created within the same `Context`.
-  This case can be trivially solved.
-- There is a collision with the `Node` name created from another `Context`.
-  By the nature of discovery, when a collision is detected, it's not possible to know what `Node` was created first without extra information.
-  A collision resolution mechanism have to be decided for solving which `Node` continues living.
-  A `timestamp` of the `Node` creation published in the state message can help to solve the problem.
-
-If we don't change the `Node` to `Participant` mapping, the last item still stands and should be solved in a similar fashion.
+Previously, each node could have different security artifacts.
+That was possible because each node was mapped to one `Participant`.
+The new approach allows to specify different security artifacts for each process.
+For more details, see [ROS 2 Security Enclaves](ros2_security_enclaves.md).
 
 #### Ignore local publications option
 
@@ -243,21 +133,23 @@ This wasn't implemented in all the rmw implementations (e.g.: [FastRTPS](https:/
 After this change, implementing this feature will be less direct.
 Some extra logic needs to be added in order to identify from which `Node` a `Publisher` was created.
 
+## Alternative implementations
 
-#### Intra process communication
+### Using keyed topics
 
-Currently, intra-process communication can be enable disabled in each `Publisher` and `Subscription`.
-An important reason for being able to selectively enable intra-process is that intraprocess communication doesn't support all QoS policies.
+Keyed topics could be used, with the participant gid as the key.
+That would allow the reader side of the topic to use a keep last, depth 1 history.
 
-Inter process messages from `Publishers` that can also communicate with a `Subscription` using the intra process layer are ignored before handling the callback.
-The same problem will happen when having only one `Participant` per context, and it can be solved in the same fashion.
+### Using participant/writer/reader user data
 
-If in the future our intra process communication support all the QoS policies, we could forbid the possibility of enabling and dissabling it at `Node`, `Publisher`, `Subscription` level.
+Instead of using a custom topic to share the extra ROS specific discovery information, a combination of participant/reader/writer user data could be used.
+e.g.:
 
-#### Launching rclpy nodes
+- Participant user data: list of nodes created by the participant (updated when node created destroyed).
+- Reader user data: node name/namespace.
+- Writer user data: node name/namespace.
 
-In `Dashing` and before, a container for dynamically composing `rclpy Nodes` is not available.
-If this is not added, launching multiple `rclpy Nodes` in a launch file will create multiple participants.
-That will make the performance worse, compared with composing `rclcpp Nodes`.
-A `rclpy` component container should be added to solve the problem.
-A generic container can also be considered, allowing to dynamically load `Nodes` from both clients.
+That information would be enough to satisfy ros2 required graph API.
+This mechanism will also avoid to have a topic where all nodes need to have write and read access.
+
+This alternative wasn't implemented because of lack of support in some of the currently supported DDS vendors.

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -169,15 +169,12 @@ There are two alternatives:
 - Add the concept of `Context` name (or `Participant` name).
   In this way, the key of each participant could be specified independently.
 - Use one key per process.
-  All the `Participants` within one process will use the same key (is that possible?).
+  All the `Participants` within one process will use the same key.
 
 ##### How to specify access policies?
 
 Access control policies could still be specified per `Node` basis.
 When a `Participant` is created, it should look at the access control policies of each of its `Nodes` and compose them in a single configuration.
-
-QQ:
-- Is it possible to add more access control policies after creating the `Participant` (e.g.: When later creating a `Node`).
 
 #### Node Name Uniqueness
 

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -1,0 +1,213 @@
+---
+layout: default
+title: Node to Participant mapping
+permalink: articles/node_to_participant_mapping.html
+abstract: This article analyze the performance implications of having a one-to-one Node to Participant mapping and propose an alternative approach.
+  How Nodes are mapped to DDS participants.
+author: '[Ivan Paunovic](https://github.com/ivanpauno)'
+published: true
+categories: Middleware
+---
+
+{:toc}
+
+# {{ page.title }}
+
+<div class="abstract" markdown="1">
+{{ page.abstract }}
+</div>
+
+Original Author: {{ page.author }}
+
+## Introduction
+
+### What is a `Node`?
+
+In ROS, a `Node` is an entity used to group other entities.
+For example: `Publishers`, `Subscriptions`, `Services`, `Clients`.
+`Nodes` ease organization and code reusage, as they can be composed or launched in different ways.
+
+### What is a `Domain Participant`?
+
+A `Domain Participant` is a type of DDS entity.
+`Participants` also group other entities, like `Publishers`, `Subscribers`, `Data Writters`, `Data Readers`, etc.
+But participants do more than that:
+
+- Each `Participant` does discovery by its own.
+  Creating more than one `Participant` increase cpu and network.
+- Each `Participant` keeps track of the others and of each DDS entity.
+  Using more than one will duplicate that data.
+- Each `Participant` creates multiple threads for event handling, discovery, etc.
+  Creating more than one will increase cpu and memory usage.
+
+For those reasons, `Participants` are heavyweight.
+
+### Current status
+
+There is a one to one map between `Nodes` and `DDS Participants`.
+This simplified the design, as `DDS Participants` provide the same organization that a `Node` needs.
+The drawback of this approach, is that performance is deteriorated.
+Furthermore, the number of `Domain participants` is limited to a small number.
+For example, [RTI connext](https://community.rti.com/kb/what-maximum-number-participants-domain) is limited to 120 participants per domain.
+
+## Proposal
+
+The goal of this proposal is to improve overall performance by avoiding the creation of one `Domain Participant` per `Node`.
+API changes will be avoided, if possible.
+
+### What is a participant mapped to?
+
+There are two main alternatives:
+- One participant per process.
+- One participant per context.
+
+The second approach allows more flexibility.
+Considering that by default there's only one context per process, it won't lower the performance.
+Moreover, a mechanism for using the same participant in two context could be added.
+
+### What is a Node now?
+
+There's not lightweight DDS entity similar to a ROS `Node`, so `Nodes` have to be built from scratch.
+A `Node` should be able to:
+- Create other entities as `Publishers`, `Subscriptions`, `Services` and `Clients`.
+  `Nodes` should own those entities, that is to say, those entity shouldn't outlive a `Node`.
+- List all its entities.
+
+For all the entities, it should be possible to get the `Node` what created them.
+Each `Participant` should store all the information needed about its nodes, and communicate it to the others.
+
+### How `Node` information is communicated?
+
+#### Using a topic
+
+The name of all the available `Nodes`, and its `Publishers`, `Subscriptions`, `Services`, `Clients` should be available for every `Participant`.
+This information can be communicated using a `topic`.
+That topic will be an implementation detail and hidden to the user.
+
+A message could be send for:
+- Each `Node`
+- Each `Participant`
+
+The second option reduces the amount of messages and it does lifetime management easier, as the message will not be more available after the `Participant` is deleted (using the correct QoS policies).
+In the following, the second option will be considered.
+
+##### State Message
+
+Each `Participant` will send a message representing their state.
+A keyed topic could be used for communicating it.
+It's reasonable to organize the data by `Participant`, so the `Participant` guid can be used as the key.
+The rest of the message will be a vector of with the information of each node.
+That message should contain the `Node` name, and four vectors:
+- guid of its `Publishers`
+- guid of its `Subscriptions`
+- guid of its `Services`
+- guid of its `Clients`
+
+Vector bounds: TBD
+
+##### QoS for communicating node information
+
+Each published message should be available to late subscriptions, and only the last message of each key is needed.
+For that reason, the QoS of the `Publishers` should be:
+
+- Durability: Transient Local
+- History: Keep Last
+- History depth: 1
+- Reliability: Reliable
+
+Considering that a keyed topic will be used, in which the history depth apply for each key, only one `Publisher` per process will be needed.
+
+The configuration of the `Subscriber` QoS depends on how the data will be accessed later:
+- Polled using `Subscriber` read method when needed.
+- Listened and organized in a local cache.
+
+The second option allows better organization of this information (e.g.: in hash tables).
+In the first case, the QoS of the `Subscriber` should be:
+
+- Durability: Transient Local
+- History: Keep Last
+- History depth: 1
+- Reliability: Reliable
+
+In the second case, durability can be changed to `Volatile`.
+
+#### Using USER_DATA and GROUP_DATA QoSPolicy
+
+Each `Participant` could have in its user data the list of node names that owns.
+When this data is changed, each `ParticipantListener` will be notified.
+This is not a good option, as `UserData` is just a sequence of bytes, and communicating a list of node names in it doesn't seem as a reasonable solution.
+
+Similarly to `UserData`, `GroupData` is a available in `Publishers` and `Subscribers`.
+These entities only need to communicate the guid of the `Participant` and the `Node` name from which it was created.
+This idea can be combined with a topic just publishing the list of `Node` names, without including all the other vectors in the message.
+Although, it is more difficult to communicate this information for `Services` and `Clients`, as they use behind the scenes just a `DDS Publisher` and `Subscriber`.
+
+### Other implications
+
+#### Security
+
+In `DDS`, security can be specified at a `Participant` level.
+Currently, as each `Node` was mapped to one `Participant`, we can individually configure its security key and access control policy.
+From a security point of view, only being able to configure it at a `Participant` (or per process) level is enough.
+There's not much sense on having different access control policies for `Nodes` in the same process.
+As they share the same address space, other vulnerabilities are possible.
+
+##### How to create a new security key?
+
+Before, we were creating a key for each `Node`.
+The full name of the node was used for creating it.
+
+If we create one `Participant` per context, we will only need a key for each of them, and not one per `Node`.
+There are two alternatives:
+
+- Add the concept of `Context` name (or `Participant` name).
+  In this way, the key of each participant could be specified independently.
+- Use one key per process.
+  All the `Participants` within one process will use the same key (is that possible?).
+
+##### How to specify access policies?
+
+Access control policies could still be specified per `Node` basis.
+When a `Participant` is created, it should look at the access control policies of each of its `Nodes` and compose them in a single configuration.
+
+QQ:
+- Is it possible to add more access control policies after creating the `Participant` (e.g.: When later creating a `Node`).
+
+#### Node Name Uniqueness
+
+We aren't currently enforcing `Node` name uniqueness.
+
+When creating only one `Participant` per `Context`, we can distinguish two cases:
+- There is an overlap between the name of two `Nodes` created within the same `Context`.
+  This case can be trivially solved.
+- There is a collision with the `Node` name created from another `Context`.
+  By the nature of discovery, when a collision is detected, it's not possible to know what `Node` was created first without extra information.
+  A collision resolution mechanism have to be decided for solving which `Node` continues living.
+  A `timestamp` of the `Node` creation published in the state message can help to solve the problem.
+
+If we don't change the `Node` to `Participant` mapping, the last item still stands and should be solved in a similar fashion.
+
+#### Ignore local publications option
+
+Currently, there's an `ignore_local_publications` option that can be set when [creting a subscription](https://github.com/ros2/rmw/blob/2250b3eee645d90f9e9d6c96d71ce3aada9944f3/rmw/include/rmw/rmw.h#L517).
+That option avoids receiving messages from `Publishers` within the same `Node`.
+This wasn't implemented in all the rmw implementations (e.g.: [FastRTPS](https://github.com/ros2/rmw_fastrtps/blob/099f9eed9a0f581447405fbd877c6d3b15f1f26e/rmw_fastrtps_cpp/src/rmw_subscription.cpp#L118)).
+
+For emulating this behavior, messages could be ignored by checking from what `Node` the `Publisher` was created.
+This should be possible by querying the state messages, or the local chache were they are organized.
+
+
+#### Intra process communication
+
+Currently, intra-process communication can be enable disabled in each `Publisher` and `Subscription`.
+There is only one reason for that: intraprocess communication doesn't support all the QoS feature.
+
+Inter process messages from `Publishers` that can also communicate with a `Subscription` using the intra process layer are ignored before handling the callback.
+The same problem will happen when having only one `Participant` per context, and it can be solved in the same fashion.
+
+If in the future our intra process communication support all the QoS policies, we could forgive the possibility of enabling and dissabling it at `Node`, `Publisher`, `Subscription` level.
+Configuring intra process communication with `Context` granularity should be enough.
+
+## References
+
+- [RTI best practices: Create as Few DomainParticipants as Possible](https://community.rti.com/best-practices/create-few-domainparticipants-possible).

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -69,7 +69,7 @@ There are two alternatives, besides the one-to-one Node to Participant mapping u
 - Using one Participant per process.
 - Using one Participant per Context.
 
-The second approach is much more flexibility, allowing more than one Participant in a single application for those that need it e.g. domain bridge applications.
+The second approach is much more flexible, allowing more than one Participant in a single application for those that need it e.g. domain bridge applications.
 Thus, a one-to-one Participant to Context mapping was chosen.
 
 When multiple Nodes are running in a single process, there are different options for grouping them by - ranging from a separate context for each Node, over grouping a few Nodes in the same context, to using a single context for all Nodes.

--- a/articles/151_node_to_participant_mapping.md
+++ b/articles/151_node_to_participant_mapping.md
@@ -35,13 +35,13 @@ Creating more Participants adds overhead to an application:
 - Each Participant participates in discovery.
   Creating more than one Participant usually increases CPU usage and network IO load.
 - Each Participant keeps track of other DDS entities.
-  Using more than one within a single process will result in data duplication.
+  Using more than one within a single process may result in data duplication.
 - Each Participant may create multiple threads for event handling, discovery, etc.
-  The number of threads created per Participant depend on the DDS vendor (e.g.: [RTI Connext](https://community.rti.com/best-practices/create-few-domainParticipants-possible)).
+  The number of threads created per Participant depends on the DDS vendor (e.g.: [RTI Connext](https://community.rti.com/best-practices/create-few-domainParticipants-possible)).
 
 For those reasons, a Participant is a heavyweight entity.
 
-Note: This might actually depend on the DDS implementation, some of them share these resources between Participants (e.g. OpenSplice).
+Note: This might actually depend on the DDS vendor, some of them share these resources between Participants (e.g. `OpenSplice`).
 Many DDS vendors, however, do not perform this kind of optimization (e.g.: `RTI Connext` and `Fast-RTPS`), and actually recommend creating just one Participant per process.
 
 ### Context
@@ -69,10 +69,10 @@ There are two alternatives, besides the one-to-one Node to Participant mapping u
 - Using one Participant per process.
 - Using one Participant per Context.
 
-The second approach allows more flexibility, and it will allow creating more than one Participant for applications that need it e.g. domain bridge applications.
+The second approach is much more flexibility, allowing more than one Participant in a single application for those that need it e.g. domain bridge applications.
 Thus, a one-to-one Participant to Context mapping was chosen.
 
-When the case where multiple Nodes are running in a single process, there are different options for grouping them by - ranging from a separate context for each Node, over grouping a few Nodes in the same context, to using a single context for all Nodes.
+When multiple Nodes are running in a single process, there are different options for grouping them by - ranging from a separate context for each Node, over grouping a few Nodes in the same context, to using a single context for all Nodes.
 For most applications, only one Context is created.
 
 ### Discovery information
@@ -100,7 +100,7 @@ This topic is considered an implementation detail, and not all `rmw` implementat
 Thus, all the necessary logic has to be in the rmw implementation itself or in an upstream package.
 Implementing this logic in `rcl` would make it part of the API, and not an implementation detail.
 
-To avoid code repetition, a common implementation of the logic was done in [rmw_dds_common](https://github.com/ros2/rmw_dds_common/).
+To avoid code repetition, a common implementation of this logic is provided by the [rmw_dds_common](https://github.com/ros2/rmw_dds_common/) package.
 
 #### Details of the ROS discovery topic
 
@@ -149,7 +149,7 @@ Instead of using a custom topic to share the extra ROS specific discovery inform
 - Reader user `userData`: Node name/namespace.
 - Writer user `userData`: Node name/namespace.
 
-That information would be enough to satisfy ROS 2 required graph API.
+That information would be enough to satisfy ROS required graph API.
 This mechanism would also preclude having a topic that has to be read and written by all Nodes, which is better from a security perspective.
 
 This alternative wasn't implemented because of lack of support in some of the currently supported DDS vendors.


### PR DESCRIPTION
Adding a document analyzing the drawbacks of enforcing a one-to-one mapping between `ROS Nodes` and `DDS Participants` and proposing alternative approaches.