### PR TITLE
Add launch XML substitution for a packages share directory

### DIFF
--- a/articles/151_roslaunch_xml.md
+++ b/articles/151_roslaunch_xml.md
@@ -65,7 +65,7 @@ The included launch file description is not necessarily written in this format n
 
 ```xml
 <include file="/opt/my_launch_file.py"/>
-<include file="$(find-pkg my_pkg)/launch/some_launch_file.xml"/>
+<include file="$(find-pkg-share my_pkg)/launch/some_launch_file.xml"/>
 <include file="/opt/my_other_launch_file.xml">
   <arg name="some_argument" value="dummy_value"/>
 </include>
@@ -239,8 +239,13 @@ All substitutions are enclosed by `$(...)`.
 
 ### Built-in Substitutions
 
-`$(find-pkg <pkg-name>)`
+`$(find-pkg-prefix <pkg-name>)`
 : Substituted by the install prefix path of the given package.
+  Forward and backwards slashes will be resolved to the local filesystem convention.
+  Substitution will fail if the package cannot be found.
+
+`$(find-pkg-share <pkg-name>)`
+: Substituted by the share directory path of the given package.
   Forward and backwards slashes will be resolved to the local filesystem convention.
   Substitution will fail if the package cannot be found.
 

--- a/articles/151_roslaunch_xml.md
+++ b/articles/151_roslaunch_xml.md
@@ -246,6 +246,7 @@ All substitutions are enclosed by `$(...)`.
 
 `$(find-pkg-share <pkg-name>)`
 : Substituted by the share directory path of the given package.
+  The share directory includes the package's name, e.g. `<prefix>/share/<pkg-name>`.
   Forward and backwards slashes will be resolved to the local filesystem convention.
   Substitution will fail if the package cannot be found.
 


### PR DESCRIPTION
Rename find-pkg to find-pkg-prefix.
Add find-pkg-share substitution for the share directory.

Implementation is in https://github.com/ros2/launch_ros/pull/57