### PR TITLE
Design Document for Zero-Copy via Loaned Messages

### DIFF
--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -26,15 +26,15 @@ This document outlines desired changes in the middleware and client libraries re
 
 The motivation for message loaning is to increase performance and determinism in ROS2.
 
-As additional motivation, there are specific middle implementations that allow for zero-copy via shared memory mechanisms.
+As additional motivation, there are specific middleware implementations that allow for zero-copy via shared memory mechanisms.
 These enhancements would allow ROS2 to take advantage of the shared memory mechanisms exposed by these implementations.
-An example of zero-copy transfer is [RTI Connext DDS Micro](https://community.rti.com/static/documentation/connext-micro/3.0.0/doc/html/usersmanual/zerocopy.html)
+An example of zero-copy transfer is [RTI Connext DDS Micro](https://community.rti.com/static/documentation/connext-micro/3.0.0/doc/html/usersmanual/zerocopy.html).
 
 ### Publisher Use Cases
 
 There are two primary kinds of use cases when publishing data which are relevant in this article:
 
-1. The user creates and owns an instance of a message which they which to publish and then reuse after publishing.
+1. The user creates and owns an instance of a message which they wish to publish and then reuse after publishing.
 2. The user borrows a message instance from the middleware, copies data into the message, and returns the ownership of the message during publish.
 
 Currently, only the first case is possible with the `rclcpp` API.
@@ -45,7 +45,7 @@ In order to support the second use case, we need a way for the user to get at le
 In the second case, the memory that is used for the loaned message should be optionally provided by the middleware.
 For example, the middleware may use this opportunity to use a preallocated pool of message instances, or it may return instances of messages allocated in shared memory.
 However, if the middleware does not have special memory handling or preallocations, it may refuse to loan memory to the client library, and in that case, a user provided allocator should be used.
-This allows the user to have control over the allocation of the message when the middleware would otherwise use the standard allocator (new/malloc)
+This allows the user to have control over the allocation of the message when the middleware might otherwise use the standard allocator (new/malloc).
 
 #### Additional Publisher Use Case
 
@@ -101,7 +101,7 @@ These requirements are driven by idiosyncrasies of various middleware implementa
 
 #### RTI Connext DDS
 
-* The Connext API (more generally the DDS API) requires that you use a sequence of messages when taking or reading.
+* The Connext API (more generally the DDS API) requires that the user to use a sequence of messages when taking or reading.
   * This means the ROS API needs to do the same, otherwise the middleware would be giving a "loan" to a message in a sequence, but it would also need to keep the sequence immutable.
 * Needs to keep sample and sample info together, therefore `rclcpp` loaned message sequence needs to own both somehow.
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -38,13 +38,13 @@ There are two primary kinds of use cases when publishing data which are relevant
 2. The user borrows a message instance from the middleware, copies data into the message, and returns the ownership of the message during publish.
 
 Currently, only the first case is possible with the `rclcpp` API.
-After calling publish, the user still owns the message and may reuse it immedeately.
+After calling publish, the user still owns the message and may reuse it immediately.
 
 In order to support the second use case, we need a way for the user to get at least a single message from the middleware, which they may then populate, then return when publishing.
 
 In the second case, the memory that is used for the loaned message should be optionally provided by the middleware.
 For example, the middleware may use this opportunity to use a preallocated pool of message instances, or it may return instances of messages allocated in shared memory.
-However, if the middleware does not have special memory handling or preallocations, it may refuse to loan memory to the client library, and in that case, a user provided allocator should be used.
+However, if the middleware does not have special memory handling or pre-allocations, it may refuse to loan memory to the client library, and in that case, a user provided allocator should be used.
 This allows the user to have control over the allocation of the message when the middleware might otherwise use the standard allocator (new/malloc).
 
 #### Additional Publisher Use Case
@@ -62,19 +62,19 @@ There are two ways the users may take message instances from a subscription when
 1. Taking direction from the `Subscription` after polling it for data availability or waiting via a wait set.
 2. Using an `Executor`, which takes the data from the user and delivers it via a user-defined callback.
 
-Note: It is assumed that the user will be abe to take multiple messages at a time if they are available.
+Note: It is assumed that the user will be able to take multiple messages at a time if they are available.
 
 In the first case, the user could choose to either:
 
 * Manage the memory for the message instance themselves, providing a reference to it, into which the middleware should fill the data.
 * Take one or more loaned messages from the middleware and return the loans later.
 
-In the second case, the user is delegating the memory management ot he client library via the `Executor`.The `Executor` may or may not borrow data from the middleweare, but the user callback does not care, so this can be considered an implementation detail.
+In the second case, the user is delegating the memory management of the client library via the `Executor`.The `Executor` may or may not borrow data from the middleware, but the user callback does not care, so this can be considered an implementation detail.
 The user should be able to influence what the `Executor` does, and in the case that memory needs to be allocated, the user should be able to provide an allocator or memory management strategy which would influence the `Executor`'s behavior.
 
 ## Requirements
 
-Based on the the use cases above, the general requirements are as follows:
+Based on the use cases above, the general requirements are as follows:
 
 * Users must be able to avoid all memory operations and copies in at least one configuration.
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -142,8 +142,8 @@ Extend publisher API for loaned messages:
 ```
 rmw_ret_t
 rmw_publish_loaned_message(
-  const rmw_publisher_t * publisher
-  const void * ros_message
+  const rmw_publisher_t * publisher,
+  const void * ros_message,
   rmw_publisher_allocation_t * allocation
 );
 ```
@@ -154,7 +154,7 @@ Because a subscription does not necessarily allocate new memory for the loaned m
 ```
 rmw_ret_t
 rmw_take_loaned_message(
-  const rmw_subscription_t * subscription
+  const rmw_subscription_t * subscription,
   void ** loaned_message,
   bool * taken,
   rmw_subscription_allocation_t * allocation

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: Zero Copy via Loaned Messages
+permalink: articles/zero_copy.html
+abstract:
+author: '[Karsten Knese](https://github.com/karsten1987) [William Woodall](https://github.com/wjwwood) [Michael Carroll](https://github.com/mjcarroll)'
+published: false
+---
+
+{:toc}
+
+# {{ page.title }}
+
+<div class="abstract" markdown="1">
+{{ page.abstract }}
+</div>
+
+## Overview
+
+There is a need to eliminate unnecessary copies throughout the ROS2 stack to maximize performance and determinism.
+In order to eliminate copies, the user must have more advanced control over memory management in the client library and middleware.
+One method of eliminating copies is via message loaning, that is the middleware can loan messages that are populated by the end user.
+This document outlines desired changes in the middleware and client libraries required to support message loaning.
+
+## Motivation
+
+The motivation for message loaning is to increase performance and determinism in ROS2.
+
+As additional motivation, there are specific middle implementations that allow for zero-copy via shared memory mechanisms.
+These enhancements would allow ROS2 to take advantage of the shared memory mechanisms exposed by these implementations.
+An example of zero-copy transfer is [RTI Connext DDS Micro](https://community.rti.com/static/documentation/connext-micro/3.0.0/doc/html/usersmanual/zerocopy.html)
+
+### Publication Use Cases
+
+There are two primary kinds of use cases when publishing data which are relevant in this article:
+
+1. The user creates and owns an instance of a message which they which to publish and then reuse after publishing.
+2. The user borrows a message instance from the middleware, copies data into the message, and returns the ownership of the message during publish.
+
+Currently, only the first case is possible with the `rclcpp` API.
+After calling publish, the user still owns the message and may reuse it immedeately.
+
+In order to support the second use case, we need a way for the user to get at least a single message from the middleware, which they may then populate, then return when publishing.
+
+In the second case, the memory that is used for the loaned message should be optionally provided by the middleware.
+For example, the middleware may use this opportunity to use a preallocated pool of message instances, or it may return instances of messages allocated in shared memory.
+However, if the middleware does not have special memory handling or preallocations, it may refuse to loan memory to the client library, and in that case, a user provided allocator should be used.
+This allows the user to have control over the allocation of the message when the middleware would otherwise use the standard allocator (new/malloc)
+
+#### Additional Publication Use Case
+
+One additional publishing use case is allowing the user to loan the message to the middleware during asynchronous publishing.
+This use case comes up when all or part of the data being published is located in memory that the middleware cannot allocate from, e.g. a hardware buffer via memory mapped I/O or something similar, and the user wants to still have zero copy and asynchronous publishing.
+In this case, the user needs to call publish, then keep the message instance immutable until the middleware lets the user know that it is done with the loaned data.
+
+This is a narrow use case and will require additional interfaces to support, therefore it will be out of scope for this document, but it is mentioned for completion.
+
+### Subscription Use Cases
+
+There are two ways the users may take message instances from a subscription when data is available:
+
+1. Taking direction from the `Subscription` after polling it for data availability or waiting via a wait set.
+2. Using an `Executor`, which takes the data from the user and delivers it via a user-defined callback.
+
+Note: It is assumed that the user will be abe to take multiple messages at a time if they are available.
+
+In the first case, the user could choose to either:
+
+* Manage the memory for the message instance themselves, providing a reference to it, into which the middleware should fill the data.
+* Take one or more loaned messages from the middleware and return the loans later.
+
+In the second case, the user is delegating the memory management ot he client library via the `Executor`.The `Executor` may or may not borrow data from the middleweare, but the user callback does not care, so this can be considered an implementation detail.
+The user should be able to influence what the `Executor` does, and in the case that memory needs to be allocated, the user should be able to provide an allocator or memory management strategy which would influence the `Executor`'s behavior.
+
+## Requirements
+
+
+## Design Proposal

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -17,7 +17,7 @@ published: false
 
 ## Overview
 
-There is a need to eliminate unnecessary copies throughout the ROS2 stack to maximize performance and determinism.
+There is a need to eliminate unnecessary copies throughout the ROS 2 stack to maximize performance and determinism.
 In order to eliminate copies, the user must have more advanced control over memory management in the client library and middleware.
 One method of eliminating copies is via message loaning, that is the middleware can loan messages that are populated by the end user.
 This document outlines desired changes in the middleware and client libraries required to support message loaning.
@@ -59,7 +59,7 @@ This is a narrow use case and will require additional interfaces to support, the
 
 There are two ways the users may take message instances from a subscription when data is available:
 
-1. Taking direction from the `Subscription` after polling it for data availability or waiting via a wait set.
+1. Taking directly from the `Subscription` after polling it for data availability or waiting via a wait set.
 2. Using an `Executor`, which takes the data from the user and delivers it via a user-defined callback.
 
 Note: It is assumed that the user will be able to take multiple messages at a time if they are available.
@@ -156,7 +156,7 @@ rmw_ret_t
 rmw_take_loaned_message(
   const rmw_subscription_t * subscription
   void ** loaned_message,
-  book * taken,
+  bool * taken,
   rmw_subscription_allocation_t * allocation
 );
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -93,7 +93,7 @@ The following requirements should hold whether the user is polling or using a wa
 * The user must be able to get a loaned message from the middleware when calling take.
 * The user must be able to get a sequence of loaned messages from the middleware when calling take.
 * The loaned message or sequence must be returned by the user.
-* When taking a loan, the middleware should not do anything "special", that is that the user must be able to influence the allocation.
+* When not taking a loan, the middleware should not do anything "special", that is that the user must be able to influence the allocation.
 
 ### Special Requirements
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -93,7 +93,8 @@ The following requirements should hold whether the user is polling or using a wa
 * The user must be able to get a loaned message from the middleware when calling take.
 * The user must be able to get a sequence of loaned messages from the middleware when calling take.
 * The loaned message or sequence must be returned by the user.
-  * In general, users should return loans as soon as feasibly possible, as the underlying mechanism has finite resources to loan messages from. Holding loans too long may cause messages to dropped or publications to stall.
+  * In general, users should return loans as soon as feasibly possible, as the underlying mechanism has finite resources to loan messages from.
+    Holding loans too long may cause messages to dropped or publications to stall.
 * When not taking a loan, the middleware should not do anything "special", that is that the user must be able to influence the allocation.
 
 ### Special Requirements

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -223,7 +223,7 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
 
 ### RCLCPP LoanedMessage
 
-In order to support loaned messages in `rclcpp`, we tntroduce the concept of a `LoanedMessage`.
+In order to support loaned messages in `rclcpp`, we introduce the concept of a `LoanedMessage`.
 A `LoanedMessage` provides a wrapper around the underlying loan mechanisms, and manages the loan's lifecycle.
 
 ```

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -93,6 +93,7 @@ The following requirements should hold whether the user is polling or using a wa
 * The user must be able to get a loaned message from the middleware when calling take.
 * The user must be able to get a sequence of loaned messages from the middleware when calling take.
 * The loaned message or sequence must be returned by the user.
+  * In general, users should return loans as soon as feasibly possible, as the underlying mechanism has finite resources to loan messages from. Holding loans too long may cause messages to dropped or publications to stall.
 * When not taking a loan, the middleware should not do anything "special", that is that the user must be able to influence the allocation.
 
 ### Special Requirements

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -123,13 +123,15 @@ Connext Micro Specific (ZeroCopy):
 Introduce APIs for creating/destroying loaned messages, as well as structure for management:
 
 ```
-void * rmw_allocate_loaned_message(
+void *
+rmw_allocate_loaned_message(
   const rmw_publisher_t * publisher,
   const rosidl_message_type_support_t * type_support,
   size_t message_size
 );
 
-rmw_ret_t rmw_deallocate_loaned_message(
+rmw_ret_t
+rmw_deallocate_loaned_message(
   const rmw_publisher_t * publisher,
   void * loaned_message
 );
@@ -138,7 +140,8 @@ rmw_ret_t rmw_deallocate_loaned_message(
 Extend publisher API for loaned messages:
 
 ```
-rmw_ret_t rmw_publish(
+rmw_ret_t
+rmw_publish(
   const rmw_publisher_t * publisher
   const void * ros_message
   rmw_publisher_allocation_t * allocation,
@@ -157,20 +160,16 @@ Extend subscription API for taking loaned message:
 Introduce APIs for creating/destroying loaned messages, as well as structure for management:
 
 ```
-struct rcl_loaned_message_t
-{
-  rcl_publisher_t * publisher;
-  rmw_loaned_message_t * message;
-}
-
-rcl_ret_t rcl_allocate_loaned_message(
+void *
+rcl_allocate_loaned_message(
   const rcl_publisher_t * publisher,
   const rosidl_message_type_support_t * type_support,
-  size_t message_size,
-  rcl_loaned_message_t * loaned_message
+  size_t message_size
 );
 
-rcl_ret_t rcl_deallocate_loaned_message(
+rcl_ret_t
+rcl_deallocate_loaned_message(
+  const rcl_publisher_t * publisher,
   rcl_loaned_message_t * loaned_message
 );
 ```
@@ -178,11 +177,16 @@ rcl_ret_t rcl_deallocate_loaned_message(
 Extend publisher API for loaned messages:
 
 ```
-// This would not need knowledge of the rmw_publisher_t, as the message allocation
-// is tied to the publisher.
-rcl_ret_t rcl_publish(
-  const rcl_loaned_message_t * message
+rcl_ret_t
+rcl_publish(
+  const rcl_publisher_t * publisher,
+  const void * ros_message,
+  rmw_publisher_allocation_t * allocation,
+  bool is_loaned
 );
+
+bool
+rcl_publisher_can_loan_messages(const rcl_publisher_t * publisher);
 ```
 
 Extend subscription API for taking loaned message:
@@ -193,7 +197,8 @@ Extend subscription API for taking loaned message:
 
 ### RCLCPP LoanedMessage
 
-Introduce the concept of a `LoanedMessage`
+In order to support loaned messages in `rclcpp`, we tntroduce the concept of a `LoanedMessage`.
+A `LoanedMessage` provides a wrapper around the underlying loan mechanisms, and manages the loan's lifecycle.
 
 ```
 template <class MsgT, typename Alloc = std::allocator<void>>
@@ -241,5 +246,4 @@ rclcpp::Publisher::can_loan_messages()
 ```
 
 ### RCLCPP Subscription
-
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -123,32 +123,26 @@ Connext Micro Specific (ZeroCopy):
 Introduce APIs for creating/destroying loaned messages, as well as structure for management:
 
 ```
-struct rmw_loaned_message_t
-{
-  const char * implementation_identifier;
-  rmw_publisher_t * publisher;
-  void * data;
-}
-
-rmw_ret_t rmw_allocate_loaned_message(
+void * rmw_allocate_loaned_message(
   const rmw_publisher_t * publisher,
   const rosidl_message_type_support_t * type_support,
-  size_t message_size,
-  rmw_loaned_message_t * loaned_message
+  size_t message_size
 );
 
 rmw_ret_t rmw_deallocate_loaned_message(
-  rmw_loaned_message_t * loaned_message
+  const rmw_publisher_t * publisher,
+  void * loaned_message
 );
 ```
 
 Extend publisher API for loaned messages:
 
 ```
-// This would not need knowledge of the rmw_publisher_t, as the message allocation
-// is tied to the publisher.
 rmw_ret_t rmw_publish(
-  const rmw_loaned_message_t * message
+  const rmw_publisher_t * publisher
+  const void * ros_message
+  rmw_publisher_allocation_t * allocation,
+  bool is_loaned
 );
 ```
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -24,10 +24,10 @@ This document outlines desired changes in the middleware and client libraries re
 
 ## Motivation
 
-The motivation for message loaning is to increase performance and determinism in ROS2.
+The motivation for message loaning is to increase performance and determinism in ROS 2.
 
 As additional motivation, there are specific middleware implementations that allow for zero-copy via shared memory mechanisms.
-These enhancements would allow ROS2 to take advantage of the shared memory mechanisms exposed by these implementations.
+These enhancements would allow ROS 2 to take advantage of the shared memory mechanisms exposed by these implementations.
 An example of zero-copy transfer is [RTI Connext DDS Micro](https://community.rti.com/static/documentation/connext-micro/3.0.0/doc/html/usersmanual/zerocopy.html).
 
 ### Publisher Use Cases


### PR DESCRIPTION
Design document for using loaned messages to provide support for zero-copy middleware implementations.

This is from notes that @Karsten1987 and @wjwwood composed, reformatted and expanded.