### PR TITLE
Add documentation on node parameter

### DIFF
--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -191,7 +191,7 @@ ROS 1 has this feature using either the environment variable `ROS_NAMESPACE` or 
 ### Change the Node Name
 
 The node name is used in log messages and to create private names.
-ROS 1 has this feature using the argument `__node`.
+ROS 1 has this feature using the argument `__name`.
 
 *Example:*
 
@@ -271,7 +271,7 @@ The operators `*` and `**` are similar to the globbing behavior in bash.
 `**` behaves similar to its use in bash>=4.0 with the globstar option set.
 
 The URL schemes `rosservice://` and `rostopic://` may only be given to topic or service name rules.
-They may not be prefixed to a node name or namespace replacement rule (`__node` or `__ns`).
+They may not be prefixed to a node name or namespace replacement rule (`__name`, `__node`, or `__ns`).
 If both a node name prefix and URL scheme are given, the node name prefix must come first.
 
 `*`, and `**` match whole tokens only.
@@ -316,7 +316,7 @@ The replacement side of a rule must have a FQN which will become the new default
 
 #### Special Rule for Changing the Node Name
 
-The string `__node` can be given on the match part of a rule to signal a change of the node's name.
+The strings `__name` or  `__node` can be given on the match part of a rule to signal a change of the node's name.
 On the match side it may be used by itself or with a `nodename:` prefix.
 The replacement must be a single token which will become the node's new name.
 
@@ -438,16 +438,18 @@ All relative names are expanded to the new namespace before any remapping rules 
 #### Supporting: Change the Node Name
 
 This also isn't a true remapping rule, but the syntax is similar.
-In ROS 1 the argument `__node:=` could change the node's name.
+In ROS 1 the argument `__name:=` could change the node's name.
 Here the syntax is the same, and additionally it can be prefixed with a node's current name.
+The argument `__node:=` is identical.
 The replacement side must have a single token.
 Log messages use the new name immediately.
 All private names are expanded to the new name before any remapping rules are applied to them.
 
 *Examples:*
 
-- `__node:=lef_camera_driver`
-- `camera_driver:__node:=left_camera_driver`
+- `__name:=left_camera_driver`
+- `__node:=left_camera_driver`
+- `camera_driver:__name:=left_camera_driver`
 
 #### Supporting: Remap Topic and Service Names Separately
 Specifying a URL scheme on the match side of the rule makes it exclusive to one type of name.

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -440,7 +440,7 @@ All relative names are expanded to the new namespace before any remapping rules 
 This also isn't a true remapping rule, but the syntax is similar.
 In ROS 1 the argument `__name:=` could change the node's name.
 Here the syntax is the same, and additionally it can be prefixed with a node's current name.
-The argument `__node:=` is identical.
+The argument `__node:=` has the same effect.
 The replacement side must have a single token.
 Log messages use the new name immediately.
 All private names are expanded to the new name before any remapping rules are applied to them.


### PR DESCRIPTION
Update the documentation to indicate that the `__name` parameter provides the same functionality as `__node`.  Also fix some incorrect references to ROS1 behavior.

Related to ros2/rcl#258.