### PR TITLE
Update launch frontend <let> attribute

### DIFF
--- a/articles/151_roslaunch_xml.md
+++ b/articles/151_roslaunch_xml.md
@@ -95,8 +95,8 @@ The `<let>` tags allows for definition of scoped launch file configuration varia
 ##### Examples
 
 ```
-<let var="foo" value="$(env BAR)"/>
-<let var="baz" value="false"/>
+<let name="foo" value="$(env BAR)"/>
+<let name="baz" value="false"/>
 ```
 
 #### `<arg>` Tag


### PR DESCRIPTION
The actually implementation uses the attribute `name` instead of `var`.