### PR TITLE
Update remapping order of __ns and __node to not affect each other

### DIFF
--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -255,7 +255,6 @@ Example rules are:
 - `foo:=bar`
 - `/foo/bar:=fiz/buzz`
 - `nodename:~/foo:=foo`
-- `/ns1/nodename:foo:=bar`
 - `**/foo:=\1/bar`
 
 #### Match Part of a Rule
@@ -266,7 +265,7 @@ The match part of a rule uses these operators:
 - `**` matches zero or more tokens delimited by slashes
 - `rosservice://` prefixed to the match makes the rule apply to only services
 - `rostopic://` prefixed to the match makes the rule apply to only topics
-- `nodename:` prefixed to the match makes it apply only to a node with that name, which could be a FQN
+- `nodename:` prefixed to the match makes it apply only to a node with that name
 
 The operators `*` and `**` are similar to the globbing behavior in bash.
 `**` behaves similar to its use in bash>=4.0 with the globstar option set.
@@ -325,8 +324,7 @@ The replacement must be a single token which will become the node's new name.
 
 Remapping rules are applied in the following order:
 
-1. Namespace remapping
-1. Node name remapping
+1. Namespace or Node name remapping
 1. All other rules
 
 Within each category, the rules are applied in the order in which the user gave them.
@@ -340,8 +338,8 @@ Within each category, the rules are applied in the order in which the user gave 
 **Example of node/namespace remapping order:**
 
 - A node has name `talker`
-- A user gives the rules `talker:__ns:=/my_namespace` then `/talker:__node:=foo`
-- The final node name is the default `talker` because the namespace remap is applied before the node name remap
+- A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`
+- The final node name is `foo` because the namespace and node name remap are applied without affecting each other
 
 **Example of a default and node specific namespace remap:**
 

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -339,7 +339,7 @@ Within each category, the rules are applied in the order in which the user gave 
 
 - A node has name `talker`
 - A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`, or vice versa
-- The final fully qualified name is `/my_namespace/foo` because the namespace and node name remap are applied without affecting each other
+- The final fully qualified name is `/my_namespace/foo` because the namespace and node name remap rules both match against the orignal node name before remappings are applied
 
 **Example of a default and node specific namespace remap:**
 

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -339,13 +339,19 @@ Within each category, the rules are applied in the order in which the user gave 
 
 - A node has name `talker`
 - A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`, or vice versa
-- The final fully qualified name is `/my_namespace/foo` because the namespace and node name remap rules both match against the orignal node name before remappings are applied
+- The final fully qualified name is `/my_namespace/foo` because the namespace and node name remap rules both match against the original node name before remappings are applied
 
 **Example of a default and node specific namespace remap:**
 
 - A node has name `talker`
 - A user gives the rules `talker:__ns:=/foo` then `__ns:=/bar`
 - talker's namespace is `/foo` because that rule was given first
+
+**Example of node and topic/service remapping order:**
+
+- A node uses a name `/talker` and a topic/service name `/bar`
+- A user gives the rules `talker:__node:=foo` then `foo:bar:=/asdf`
+- The final fully qualified name is `/foo`, and the final topic/service name is `/asdf` because the node name remap rule is matched before other remappings are applied
 
 ### Applications of the syntax
 

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -255,6 +255,7 @@ Example rules are:
 - `foo:=bar`
 - `/foo/bar:=fiz/buzz`
 - `nodename:~/foo:=foo`
+- `/ns1/nodename:foo:=bar`
 - `**/foo:=\1/bar`
 
 #### Match Part of a Rule
@@ -265,7 +266,7 @@ The match part of a rule uses these operators:
 - `**` matches zero or more tokens delimited by slashes
 - `rosservice://` prefixed to the match makes the rule apply to only services
 - `rostopic://` prefixed to the match makes the rule apply to only topics
-- `nodename:` prefixed to the match makes it apply only to a node with that name
+- `nodename:` prefixed to the match makes it apply only to a node with that name, which could be a FQN
 
 The operators `*` and `**` are similar to the globbing behavior in bash.
 `**` behaves similar to its use in bash>=4.0 with the globstar option set.
@@ -324,8 +325,8 @@ The replacement must be a single token which will become the node's new name.
 
 Remapping rules are applied in the following order:
 
-1. Node name remapping
 1. Namespace remapping
+1. Node name remapping
 1. All other rules
 
 Within each category, the rules are applied in the order in which the user gave them.
@@ -339,8 +340,8 @@ Within each category, the rules are applied in the order in which the user gave 
 **Example of node/namespace remapping order:**
 
 - A node has name `talker`
-- A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`
-- The final namespace is the default `/` because the node name remap is applied before the namespace remap
+- A user gives the rules `talker:__ns:=/my_namespace` then `/talker:__node:=foo`
+- The final node name is the default `talker` because the namespace remap is applied before the node name remap
 
 **Example of a default and node specific namespace remap:**
 

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -338,8 +338,8 @@ Within each category, the rules are applied in the order in which the user gave 
 **Example of node/namespace remapping order:**
 
 - A node has name `talker`
-- A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`
-- The final node name is `foo` because the namespace and node name remap are applied without affecting each other
+- A user gives the rules `talker:__ns:=/my_namespace` then `talker:__node:=foo`, or vice versa
+- The final fully qualified name is `/my_namespace/foo` because the namespace and node name remap are applied without affecting each other
 
 **Example of a default and node specific namespace remap:**
 


### PR DESCRIPTION
I encountered an issue about remapping two nodes that originally have a different name to the same new name but with a different namespace.

ex.
there are two nodes in `examples_rclcpp_minimal_composition`, and we want to remap node names
`publisher_node` -> `/publisher_different_ns/test_same_node`
`subscriber_node` -> `/subscriber_different_ns/test_same_node`

we want to do remapping names like the following way,
```
$ ros2 run examples_rclcpp_minimal_composition composition_composed \
    --ros-args \
    -r publisher_node:__ns:=/publisher_different_ns \
    -r publisher_node:__node:=test_same_node \
    -r subscriber_node:__ns:=/subscriber_different_ns \
    -r subscriber_node:__node:=test_same_node
```
rather than using
```
$ ros2 run examples_rclcpp_minimal_composition composition_composed \
    --ros-args \
    -r test_same_node:__ns:=/publisher_different_ns \ 
    -r publisher_node:__node:=test_same_node \
    -r test_same_node:__ns:=/subscriber_different_ns \
    -r subscriber_node:__node:=test_same_node
```
, since the existing remapping order that parsing `__node` before `__ns` causes the latter command to use the same `node_name prefix of __ns` parameter for two nodes.

Related to https://github.com/ros2/rcl/issues/806

Signed-off-by: Chen Lihui <Lihui.Chen@sony.com>