### PR TITLE
Update links to colcon documentation

### DIFF
--- a/articles/101_build_tool.md
+++ b/articles/101_build_tool.md
@@ -431,7 +431,7 @@ The following items briefly enumerate what this decision means for ROS developer
 
 - **No CMake code** of any ROS 2 (or ROS 1) package **needs to be changed** for this transition.
 - When building and testing ROS 2 the command `colcon build` / `colcon test` will be used instead of `ament build` / `ament test`.
-  Please see the [documentation](http://colcon.readthedocs.io/en/latest/migration/ament_tools.html) how to map `ament_tools` command line arguments to `colcon` arguments.
+  Please see the [documentation](http://colcon.readthedocs.io/en/released/migration/ament_tools.html) how to map `ament_tools` command line arguments to `colcon` arguments.
 - For ROS 1 nothing is changing at this point in time.
 - In the future `colcon` will replace `catkin_make_isolated` and `catkin_make` as the recommended build tool for ROS 1.
   - `colcon` will not support the *devel space* and will require packages to have install rules
@@ -454,5 +454,5 @@ The following items briefly enumerate what this decision means for ROS developer
 ### Outlook
 
 - Since `colcon` can be used to build ROS 1, early adopters can try to use it to build ROS 1 from source.
-  While there is documentation how to migrate from [catkin_make_isolated](http://colcon.readthedocs.io/en/latest/migration/catkin_make_isolated.html) and [catkin_tools](http://colcon.readthedocs.io/en/latest/migration/catkin_tools.html) `colcon` won't be the recommended build tool in ROS 1 for the foreseeable future.
+  While there is documentation how to migrate from [catkin_make_isolated](http://colcon.readthedocs.io/en/released/migration/catkin_make_isolated.html) and [catkin_tools](http://colcon.readthedocs.io/en/released/migration/catkin_tools.html) `colcon` won't be the recommended build tool in ROS 1 for the foreseeable future.
 - If a test buildfarm using `colcon` proofs to deliver the exact same results as the ROS 1 buildfarm using `catkin_make_isolated` it might be changed to use `colcon` in the future to benefit from the features `colcon` provides (like non-interleaved output per package when building in parallel, per package log files, etc.).


### PR DESCRIPTION
Links to "latest" are broken.  Replacing with "released".