### PR TITLE
Update launch XML schema to rename <node> attribute ns to namespace and add ros_args

### DIFF
--- a/articles/151_roslaunch_xml.md
+++ b/articles/151_roslaunch_xml.md
@@ -81,7 +81,7 @@ The `<group>` tag allows for launch actions' grouping as well as optional launch
 
 ```xml
 <group scoped="true">
-  <node pkg="a_ros_package" name="dummy0" ns="my_ns" exec="dummy_node"/>
+  <node pkg="a_ros_package" name="dummy0" namespace="my_ns" exec="dummy_node"/>
   <node pkg="a_ros_package" name="dummy1" exec="dummy_node"/>
 </group>
 ```

--- a/articles/specs/launch.0.1.1.xsd
+++ b/articles/specs/launch.0.1.1.xsd
@@ -553,7 +553,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="ns" type="xs:string" use="optional">
+      <xs:attribute name="namespace" type="xs:string" use="optional">
         <xs:annotation>
           <xs:documentation xml:lang="en">
             A ROS namespace to scope the launched ROS node.

--- a/articles/specs/launch.0.1.1.xsd
+++ b/articles/specs/launch.0.1.1.xsd
@@ -546,6 +546,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="ros_args" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            ROS-specific 'command-line' arguments for the ROS node.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="args" type="xs:string" use="optional">
         <xs:annotation>
           <xs:documentation xml:lang="en">


### PR DESCRIPTION
Closes #317

This renames the `<node>` `ns` attribute to `namespace` (#317). This also adds a new `ros_args` attribute, see https://github.com/ros2/launch_ros/pull/253.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>