### PR TITLE
Add format+example for adding year+last modified year for each article

### DIFF
--- a/articles/010_why_ros2.md
+++ b/articles/010_why_ros2.md
@@ -6,6 +6,8 @@ abstract:
   This article captures the reasons for making breaking changes to the ROS API, hence the 2.0.
 published: true
 author: Brian Gerkey
+written: 2014
+last_modified: 2015
 categories: Overview
 ---
 
@@ -17,7 +19,9 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Original Author: {{ page.author }}  
+Written: {{ page.written }}  
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.written }}{% endif %}
 
 We started work on ROS in November 2007.
 A lot has happened since then and we believe that it is now time to build the next generation ROS platform.

--- a/articles/010_why_ros2.md
+++ b/articles/010_why_ros2.md
@@ -19,8 +19,10 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}  
-Date Written: {{ page.date_written }}  
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
 Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 We started work on ROS in November 2007.

--- a/articles/010_why_ros2.md
+++ b/articles/010_why_ros2.md
@@ -6,7 +6,7 @@ abstract:
   This article captures the reasons for making breaking changes to the ROS API, hence the 2.0.
 published: true
 author: Brian Gerkey
-written: 2014
+date_written: 2014
 last_modified: 2015
 categories: Overview
 ---
@@ -20,8 +20,8 @@ categories: Overview
 </div>
 
 Original Author: {{ page.author }}  
-Written: {{ page.written }}  
-Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.written }}{% endif %}
+Date Written: {{ page.date_written }}  
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 We started work on ROS in November 2007.
 A lot has happened since then and we believe that it is now time to build the next generation ROS platform.

--- a/articles/010_why_ros2.md
+++ b/articles/010_why_ros2.md
@@ -6,8 +6,8 @@ abstract:
   This article captures the reasons for making breaking changes to the ROS API, hence the 2.0.
 published: true
 author: Brian Gerkey
-date_written: 2014
-last_modified: 2015
+date_written: 2014-06
+last_modified: 2015-07
 categories: Overview
 ---
 

--- a/articles/020_ros_with_dds.md
+++ b/articles/020_ros_with_dds.md
@@ -6,6 +6,8 @@ abstract:
   This article makes the case for using DDS as the middleware for ROS, outlining the pros and cons of this approach, as well as considering the impact to the user experience and code API that using DDS would have.
   The results of the "ros_dds" prototype are also summarized and used in the exploration of the issue.
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2014-06
+last_modified: 2019-07
 published: true
 categories: Middleware
 ---
@@ -23,7 +25,11 @@ For details on how ROS 2 has been implemented, see the [Core Documentation](http
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 Terminology:
 

--- a/articles/030_ros_with_zeromq.md
+++ b/articles/030_ros_with_zeromq.md
@@ -8,6 +8,8 @@ abstract:
   This article also covers the results of the ZeroMQ based prototype made by OSRF.
 published: true
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2014-06
+last_modified: 2019-05
 ---
 
 {:toc}
@@ -20,7 +22,11 @@ author: '[William Woodall](https://github.com/wjwwood)'
 
 > This document pre-dates the decision to build ROS 2 on top of DDS.
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 While this article covers proposals and related experiments for building a new middleware specifically around ZeroMQ, it also generally captures the idea of building a new middleware out of a few component libraries.
 This strategy of composing existing libraries into a middleware is in contrast to wrapping up an existing end-to-end middleware which provides most if not all of the middleware needs for ROS out of the box.

--- a/articles/040_stories.md
+++ b/articles/040_stories.md
@@ -6,6 +6,8 @@ abstract:
   This article captures some stories which drive the direction of features in ROS.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2016-12
+last_modified: 2016-12
 categories: Overview
 ---
 
@@ -17,7 +19,11 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 The article enumerates a few stories which sketch what will be possible with ROS in the future.
 The list is by no means exhaustive.

--- a/articles/050_ros_rpc_design.md
+++ b/articles/050_ros_rpc_design.md
@@ -7,6 +7,8 @@ abstract:
   We focus here on specifying the user API and leave the implementation unspecified.
   It is expected that there are one or more RPC implementations which can be used, such as Apache Thrift, ROS RPC, or MsgPack.
 author: '[Tully Foote](https://github.com/tfoote)'
+date_written: 2014-06
+last_modified: 2019-05
 published: true
 ---
 
@@ -25,7 +27,11 @@ It can be considered memoranda and not necessarily the intention of how to devel
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 In ROS there are two types of Remote Procedure Call (RPC) primitives.
 ROS Services are basic request-response style RPCs, while ROS Actions additionally are preemptible and offer feedback while requests are being processed.

--- a/articles/055_ros_parameter_design.md
+++ b/articles/055_ros_parameter_design.md
@@ -6,6 +6,8 @@ abstract:
   This article is proposed design for the interfaces for interacting with parameters in ROS 2.
   We focus here on specifying the system design and leave the implementation unspecified.
 author: '[Tully Foote](https://github.com/tfoote)'
+date_written: 2015-09
+last_modified: 2019-05
 published: true
 ---
 
@@ -18,7 +20,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/060_ros_middleware_interface.md
+++ b/articles/060_ros_middleware_interface.md
@@ -7,6 +7,8 @@ abstract:
   It will outline the targeted use cases as well as their requirements and constraints.
   Based on that the developed middleware interface is explained.
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2014-08
+last_modified: 2017-09
 published: true
 categories: Middleware
 ---
@@ -19,7 +21,11 @@ categories: Middleware
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## The *middleware interface*
 

--- a/articles/080_ros_documentation_system.md
+++ b/articles/080_ros_documentation_system.md
@@ -5,6 +5,8 @@ permalink: articles/ros_documentation_system.html
 abstract:
   This article describes the proposed system for doing documentation for ROS 2.
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2015-01
+last_modified: 2016-02
 published: false
 ---
 
@@ -16,7 +18,11 @@ published: false
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 This document is meant to capture the results of discussions about the way we (the ROS 2 developers) would like documentation to work in ROS 2 and polish those results into a proposal.
 It is likely that this document should be refined and made into a REP once a suitable design is settled on.

--- a/articles/100_ament.md
+++ b/articles/100_ament.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the build system "ament_cmake" and the meta build tool "ament_tools".
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-07
+last_modified: 2018-06
 categories: Overview
 ---
 
@@ -17,7 +19,11 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 <div class="alert alert-warning" markdown="1">
 When this article was originally written `ament_tools` was the ROS 2 specific build tool.

--- a/articles/101_build_tool.md
+++ b/articles/101_build_tool.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the rationale for a universal build tool.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2017-03
+last_modified: 2021-01
 categories: Overview
 ---
 
@@ -17,7 +19,11 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Preface
 

--- a/articles/110_interface_definition.md
+++ b/articles/110_interface_definition.md
@@ -6,6 +6,8 @@ abstract:
   This article specifies the file format describing the data structures exchanged by ROS 2 components to interact with each other.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-06
+last_modified: 2020-02
 categories: Interfaces
 ---
 
@@ -21,7 +23,11 @@ With the transition to use ``IDL`` for specifying interfaces in ROS 2 Dashing th
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/111_mapping_dds_types.md
+++ b/articles/111_mapping_dds_types.md
@@ -6,6 +6,8 @@ abstract:
   This article specifies the mapping between the ROS interface types and the DDS types.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-06
+last_modified: 2020-02
 categories: Interfaces
 ---
 
@@ -21,7 +23,11 @@ With the transition to use ``IDL`` for specifying interfaces in ROS 2 Dashing th
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/112_generated_interfaces_cpp.md
+++ b/articles/112_generated_interfaces_cpp.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the generated C++ code for ROS 2 interfaces.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-06
+last_modified: 2019-03
 categories: Interfaces
 ---
 
@@ -21,7 +23,11 @@ With the transition to use ``IDL`` for specifying interfaces in ROS 2 Dashing th
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/114_generated_interfaces_python.md
+++ b/articles/114_generated_interfaces_python.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the generated Python code for ROS 2 interfaces.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2016-01
+last_modified: 2019-03
 categories: Interfaces
 ---
 
@@ -21,7 +23,11 @@ With the transition to use ``IDL`` for specifying interfaces in ROS 2 Dashing th
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/115_idl.md
+++ b/articles/115_idl.md
@@ -6,6 +6,8 @@ abstract:
   This describes defining interfaces using a subset of the [Interface Definition Language](https://www.omg.org/spec/IDL/) (IDL).
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2019-03
+last_modified: 2020-07
 categories: Interfaces
 ---
 
@@ -17,7 +19,11 @@ categories: Interfaces
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/116_legacy_interface_definition.md
+++ b/articles/116_legacy_interface_definition.md
@@ -6,6 +6,8 @@ abstract:
   This article specifies the file format coming from ROS 1 describing the data structures exchanged by ROS components to interact with each other.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2019-03
+last_modified: 2021-02
 categories: Interfaces
 ---
 
@@ -17,7 +19,11 @@ categories: Interfaces
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Scope
 

--- a/articles/117_wide_strings.md
+++ b/articles/117_wide_strings.md
@@ -6,6 +6,8 @@ abstract:
   This article describes how ROS 2 will support sending multi-byte character data using the [Unicode](https://en.wikipedia.org/wiki/Unicode) standard.
   It also describes how such data will be sent over the ROS 1 bridge.
 author: '[Chris Lalancette](https://github.com/clalancette)'
+date_written: 2019-05
+last_modified: 2020-07
 published: true
 ---
 
@@ -18,7 +20,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/120_realtime_background.md
+++ b/articles/120_realtime_background.md
@@ -5,6 +5,8 @@ permalink: articles/realtime_background.html
 abstract: This article is a brief survey of real-time computing requirements and methods to achieve real-time performance.
 published: true
 author: Jackie Kay
+date_written: 2016-01
+last_modified: 2016-05
 ---
 
 {:toc}
@@ -15,7 +17,11 @@ author: Jackie Kay
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 This document seeks to summarize the requirements of real-time computing and the challenges of implementing real-time performance.
 It also lays out options for how ROS 2 could be structured to enforce real-time compatibility.

--- a/articles/121_realtime_proposal.md
+++ b/articles/121_realtime_proposal.md
@@ -3,8 +3,10 @@ layout: default
 title: Proposal for Implementation of Real-time Systems in ROS 2
 permalink: articles/realtime_proposal.html
 abstract: Proposal for a test-driven approach to the real-time performance requirement in ROS 2.
-published: true 
+published: true
 author: Jackie Kay
+date_written: 2016-01
+last_modified: 2016-01
 ---
 
 {:toc}
@@ -15,7 +17,11 @@ author: Jackie Kay
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Requirements and Implementation of Real-Time Systems
 

--- a/articles/130_ros_time.md
+++ b/articles/130_ros_time.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the ROS primitives to support programming which can run both in real time as well as simulated time which may be faster or slower.
 published: true
 author: '[Tully Foote](https://github.com/tfoote)'
+date_written: 2018-07
+last_modified: 2015-12
 ---
 
 - This will become a table of contents (this text will be scraped).
@@ -17,7 +19,11 @@ author: '[Tully Foote](https://github.com/tfoote)'
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/140_topic_and_service_name_mapping.md
+++ b/articles/140_topic_and_service_name_mapping.md
@@ -5,6 +5,8 @@ permalink: articles/topic_and_service_names.html
 abstract:
   This article describes the proposed mapping between ROS topic and service names to DDS topic and service names.
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2016-10
+last_modified: 2018-06
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Context
 

--- a/articles/141_static_remapping.md
+++ b/articles/141_static_remapping.md
@@ -5,6 +5,8 @@ permalink: articles/static_remapping.html
 abstract:
   Topics, parameters, and services are identified by [Names](http://wiki.ros.org/Names). Names are hard coded in ROS nodes, but they can be changed at runtime through remapping. Without remapping every instance of a node would require changes in code. This article describes the requirements, rationale, and mechanisms for remapping names in ROS 2.
 author: '[Shane Loretz](https://github.com/sloretz)'
+date_written: 2017-03
+last_modified: 2020-03
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Why remap names
 

--- a/articles/150_roslaunch.md
+++ b/articles/150_roslaunch.md
@@ -5,6 +5,8 @@ permalink: articles/roslaunch.html
 abstract:
   The launch system in ROS is responsible for helping the user describe the configuration of their system and then execute it as described. The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS specific conventions which make it easy to reuse components throughout the system by giving them each different configurations. Also, because the launch system is the process (or the set of processes) which executes the user's processes, it is responsible for monitoring the state of the processes it launched, as well as reporting and/or reacting to changes in the state of those processes.
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2019-09
+last_modified: 2019-09
 published: true
 ---
 
@@ -18,6 +20,10 @@ published: true
 </div>
 
 Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Context
 

--- a/articles/151_roslaunch_xml.md
+++ b/articles/151_roslaunch_xml.md
@@ -5,6 +5,8 @@ permalink: articles/roslaunch_xml.html
 abstract:
   The XML format for declarative launch descriptions in the ROS 2 launch system.
 author: '[Michel Hidalgo](https://github.com/hidmic)'
+date_written: 2019-09
+last_modified: 2021-06
 published: true
 ---
 
@@ -18,6 +20,10 @@ published: true
 </div>
 
 Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 
 # ROS 2 Launch XML Format v0.1.0

--- a/articles/152_roslaunch_frontend.md
+++ b/articles/152_roslaunch_frontend.md
@@ -5,6 +5,8 @@ permalink: articles/roslaunch_frontend.html
 abstract:
   The launch system in ROS 2 aims to support extension of static descriptions, so as to easily allow both exposing new features of the underlying implementation, which may or may not be extensible itself, and introducing new markup languages. This document discusses several approaches for implementations to follow.
 author: '[Michel Hidalgo](https://github.com/hidmic) [William Woodall](https://github.com/wjwwood)'
+date_written: 2019-09
+last_modified: 2020-07
 published: true
 ---
 
@@ -18,6 +20,10 @@ published: true
 </div>
 
 Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Context
 

--- a/articles/160_ros_command_line_arguments.md
+++ b/articles/160_ros_command_line_arguments.md
@@ -5,6 +5,8 @@ permalink: articles/ros_command_line_arguments.html
 abstract:
   This article describes ROS 2 nodes command line arguments and their syntax.
 author: '[Michel Hidalgo](https://github.com/hidmic)'
+date_written: 2019-09
+last_modified: 2021-08
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Overview
 

--- a/articles/170_node_to_participant_mapping.md
+++ b/articles/170_node_to_participant_mapping.md
@@ -4,6 +4,8 @@ title: Node to Participant mapping
 permalink: articles/Node_to_Participant_mapping.html
 abstract: This article analyzes the performance implications of enforcing a one-to-one mapping between ROS Nodes and DDS Participants, and proposes alternative implementation approaches.
 author: '[Ivan Paunovic](https://github.com/ivanpauno)'
+date_written: 2020-06
+last_modified: 2020-07
 published: true
 categories: Middleware
 ---
@@ -16,7 +18,11 @@ categories: Middleware
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/180_ros2_dds_security.md
+++ b/articles/180_ros2_dds_security.md
@@ -10,7 +10,8 @@ abstract: >
   This article describes how ROS 2 integrates with DDS-Security.
 author:  >
   [Kyle Fazzari](https://github.com/kyrofa)
-
+date_written: 2019-07
+last_modified: 2020-07
 published: true
 categories: Security
 ---
@@ -24,7 +25,11 @@ categories: Security
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 
 # DDS-Security overview

--- a/articles/181_ros2_access_control_policies.md
+++ b/articles/181_ros2_access_control_policies.md
@@ -7,7 +7,8 @@ abstract:
 author:  >
   [Ruffin White](https://github.com/ruffsl),
   [Kyle Fazzari](https://github.com/kyrofa)
-
+date_written: 2019-08
+last_modified: 2021-06
 published: true
 categories: Security
 ---
@@ -21,7 +22,11 @@ categories: Security
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 
 [SROS 2](/articles/ros2_dds_security.html) introduces several security properties, including encryption, authentication, and authorization.

--- a/articles/182_ros2_security_enclaves.md
+++ b/articles/182_ros2_security_enclaves.md
@@ -7,7 +7,8 @@ abstract:
 author:  >
   [Ruffin White](https://github.com/ruffsl),
   [Mikael Arguedas](https://github.com/mikaelarguedas)
-
+date_written: 2020-05
+last_modified: 2020-07
 published: true
 categories: Security
 ---
@@ -21,7 +22,11 @@ categories: Security
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 This design document formalizes the integration of ROS 2 with security enclaves.
 In summary, all secure processes must use an enclave that contains the runtime security artifacts unique to that enclave, yet each process may not necessarily have a unique enclave.

--- a/articles/183_ros2_threat_model.md
+++ b/articles/183_ros2_threat_model.md
@@ -18,7 +18,8 @@ author: >
   [Borja Erice](https://github.com/borkenerice)
   [Odei Olalde](https://github.com/o-olalde)
   [David Mayoral](https://github.com/dmayoral)
-
+date_written: 2019-03
+last_modified: 2021-01
 published: true
 categories: Security
 ---
@@ -39,6 +40,12 @@ th {
 </style>
 
 # {{ page.title }}
+
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 This is a **DRAFT DOCUMENT**.
 

--- a/articles/200_migration_guide_from_ros1.md
+++ b/articles/200_migration_guide_from_ros1.md
@@ -3,9 +3,11 @@ layout: default
 title: Migration guide from ROS 1
 permalink: articles/migration_guide_from_ros1.html
 abstract:
-  This article has been moved to https://index.ros.org/doc/ros2/Contributing/Migration-Guide/.
+  This article has been moved to https://docs.ros.org/en/rolling/Contributing/Migration-Guide.html
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-07
+last_modified: 2019-02
 ---
 
 {:toc}
@@ -16,4 +18,8 @@ author: '[Dirk Thomas](https://github.com/dirk-thomas)'
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}

--- a/articles/actions.md
+++ b/articles/actions.md
@@ -6,6 +6,8 @@ abstract:
   Actions are one of the three core types of interaction between ROS nodes.
   This article specifies the requirements for actions, how they've changed from ROS 1, and how they're communicated.
 author: '[Geoffrey Biggs](https://github.com/gbiggs) [Jacob Perron](https://github.com/jacobperron) [Shane Loretz](https://github.com/sloretz)'
+date_written: 2019-03
+last_modified: 2020-05
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/changes.md
+++ b/articles/changes.md
@@ -6,6 +6,8 @@ abstract:
   This article provides an overview about the changes being made in ROS 2 compared to ROS 1.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas)'
+date_written: 2015-09
+last_modified: 2017-06
 categories: Overview
 ---
 
@@ -17,7 +19,11 @@ categories: Overview
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Preface
 

--- a/articles/cross_compilation_build_tools_design.md
+++ b/articles/cross_compilation_build_tools_design.md
@@ -9,6 +9,8 @@ author: >
   [Thomas Moulard](https://github.com/thomas-moulard),
   [Juan Rodriguez Hortala](https://github.com/juanrh),
   [Anas Abou Allaban](https://github.com/piraka9011)
+date_written: 2019-09
+last_modified: 2019-09
 published: true
 ---
 
@@ -22,7 +24,11 @@ This is a **DRAFT DOCUMENT**.
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/discovery_and_negotiation.md
+++ b/articles/discovery_and_negotiation.md
@@ -6,6 +6,8 @@ abstract:
   This article was written to try and understand the different possibilities for how the middleware could be implemented.
 published: true
 author: '[William Woodall](https://github.com/wjwwood)'
+date_written: 2014-06
+last_modified: 2019-03
 ---
 
 {:toc}
@@ -20,7 +22,11 @@ author: '[William Woodall](https://github.com/wjwwood)'
 > It does not aim to answer all implementation questions or suggest implementation strategies.
 > It simply tries to capture the concepts in the design space and identify trade-offs and relationships between design elements.
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Problem Space
 

--- a/articles/intraprocess_communication.md
+++ b/articles/intraprocess_communication.md
@@ -5,6 +5,8 @@ permalink: articles/intraprocess_communications.html
 abstract: Description of the current intra-process communication mechanism in ROS 2 and of its drawbacks. Design proposal for an improved implementation. Experimental results.
 published: true
 author: '[Alberto Soragna](https://github.com/alsora) [Juan Oxoby](https://github.com/joxoby) [Dhiraj Goel](https://github.com/dgoel)'
+date_written: 2020-03
+last_modified: 2020-03
 ---
 
 {:toc}
@@ -15,7 +17,11 @@ author: '[Alberto Soragna](https://github.com/alsora) [Juan Oxoby](https://githu
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Introduction
 

--- a/articles/node_lifecycle.md
+++ b/articles/node_lifecycle.md
@@ -6,6 +6,8 @@ abstract:
   It aims to document some of the options for supporting manage d-life cycle nodes in ROS 2.
   It has been written with consideration for the existing design of the ROS 2 C++ client library, and in particular the current design of executors.
 author: '[Geoffrey Biggs](https://github.com/gbiggs) [Tully Foote](https://github.com/tfoote)'
+date_written: 2015-06
+last_modified: 2021-02
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/per_package_documentation.md
+++ b/articles/per_package_documentation.md
@@ -4,6 +4,8 @@ title: Per-Package Documentation
 permalink: articles/per_package_documentation.html
 abstract: This article describes the requirements and design of ROS 2’s per-package documentation system.
 author: Marya Belanger
+date_written: 2020-10
+last_modified: 2020-10
 published: true
 ---
 
@@ -15,7 +17,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Background
 

--- a/articles/qos.md
+++ b/articles/qos.md
@@ -6,6 +6,8 @@ abstract:
   This article describes the approach to provide QoS (Quality of Service) policies for ROS 2.
 published: true
 author: '[Esteve Fernandez](https://github.com/esteve)'
+date_written: 2015-10
+last_modified: 2019-05
 ---
 
 {:toc}
@@ -21,7 +23,11 @@ author: '[Esteve Fernandez](https://github.com/esteve)'
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 With the advent of inexpensive robots using unreliable wireless networks, developers and users need mechanisms to control how traffic is prioritized across network links.
 

--- a/articles/qos_configurability.md
+++ b/articles/qos_configurability.md
@@ -5,6 +5,8 @@ permalink: articles/qos_configurability.html
 abstract:
   This article describes a mechanism to allow reconfiguration of QoS settings at startup time.
 author: '[Ivan Santiago Paunovic](https://github.com/ivanpauno)'
+date_written: 2020-11
+last_modified: 2020-11
 published: true
 ---
 
@@ -17,7 +19,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Summary
 

--- a/articles/qos_deadline_liveliness_lifespan.md
+++ b/articles/qos_deadline_liveliness_lifespan.md
@@ -3,8 +3,10 @@ layout: default
 title: ROS QoS - Deadline, Liveliness, and Lifespan
 permalink: articles/qos_deadline_liveliness_lifespan.html
 abstract:
-  This article makes the case for adding Deadline, Liveliness, and Lifespan QoS settings to ROS. It outlines the requirements and explores the ways it could be integrated with the existing code base. 
+  This article makes the case for adding Deadline, Liveliness, and Lifespan QoS settings to ROS. It outlines the requirements and explores the ways it could be integrated with the existing code base.
 author: '[Nick Burek](https://github.com/nburek)'
+date_written: 2019-09
+last_modified: 2019-09
 published: true
 categories: Middleware
 date: February 13th 2019
@@ -18,7 +20,11 @@ date: February 13th 2019
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 Glossary:
 
@@ -55,9 +61,9 @@ The default deadline time will be 0.
 
 ### Liveliness
 
-The liveliness policy establishes a contract for how entities report that they are still alive. 
-For Subscriptions it establishes the level of reporting that they require from the Publishers to which they are subscribed. 
-For Publishers it establishes the level of reporting that they will provide to Subscribers that they are alive. 
+The liveliness policy establishes a contract for how entities report that they are still alive.
+For Subscriptions it establishes the level of reporting that they require from the Publishers to which they are subscribed.
+For Publishers it establishes the level of reporting that they will provide to Subscribers that they are alive.
 
 Topics will support the following levels of liveliness:
 - LIVELINESS_SYSTEM_DEFAULT - Use the ROS specified default for liveliness (which is LIVELINESS_AUTOMATIC).
@@ -144,7 +150,7 @@ The design and implementation of this API is out of scope for this document and 
 
 - How does the Deadline policy take into account the additional overhead of ROS (such as deserialization) when determining if a deadline was missed?
   - As a simplification it is not going to attempt to take into account any ROS overhead. A deadline will be considered missed if the rmw layer does not receive a message by the deadline and not if the user application on top of ROS does not receive it by the deadline. A new deadline policy could be added later that takes this into account.
-- Why will the callback not get called for every status change event instead of potentially combining events of the same type? 
+- Why will the callback not get called for every status change event instead of potentially combining events of the same type?
   - Adding this functionality would require an additional buffer that would be used to store multiple events between servicing them. Additionally, the DDS API lends itself better to only being informed of the latest change and would require a realtime response to status change events so as to not miss a single event. This is not a one way door and we could change this later to allow buffering events without breaking backwards compatibility.
 - How do these QoS policies impact Actions and Services?
   - The initial implementation does not support Actions and Services as there are more complex subtleties to how these concepts natively support these QoS features. In the future work section below we explore some ways that Services could implement these policies.

--- a/articles/serialization.md
+++ b/articles/serialization.md
@@ -5,6 +5,8 @@ abstract:
   This article captures the research done in regards to the serialization component, including an overview of the current implementation in ROS 1 and the alternatives for ROS 2.
 published: true
 author: '[Dirk Thomas](https://github.com/dirk-thomas) and [Esteve Fernandez](https://github.com/esteve)'
+date_written: 2013-12
+last_modified: 2019-05
 ---
 
 {:toc}
@@ -15,7 +17,11 @@ author: '[Dirk Thomas](https://github.com/dirk-thomas) and [Esteve Fernandez](ht
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 > This document pre-dates the decision to build ROS 2 on top of DDS.
 >

--- a/articles/unique_network_flows.md
+++ b/articles/unique_network_flows.md
@@ -4,6 +4,8 @@ title: Unique Network Flows
 permalink: articles/unique_network_flows.html
 abstract: Enable unique network flow identifiers for publishers and subscriptions in communicating nodes
 author: '[Ananya Muddukrishna, Ericsson AB](https://github.com/anamud)'
+date_written: 2021-05
+last_modified: 2021-05
 published: true
 ---
 
@@ -15,7 +17,11 @@ published: true
 {{ page.abstract }}
 </div>
 
-Original Author: {{ page.author }}
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 # Unique Network Flows
 
@@ -49,10 +55,10 @@ We briefly discuss two relevant explicit QoS specification methods for applicati
 
    A frustrating problem with DS-based QoS is that intermediate routers can reset or alter the DSCP value within flows. One workaround is to carefully configure intermediate routers such that they retain DSCP markings from incoming to outgoing flows.
 
-- 5G network 5QI: The Network Exposure Function (NEF) [4] in the 5G core network provides robust and secure API for QoS specification. This API enables applications to programmatically (HTTP-JSON) specify required QoS by associating 5G QoS Identifiers (5QIs) to flow identifers, as shown in the figure next. 
-  
+- 5G network 5QI: The Network Exposure Function (NEF) [4] in the 5G core network provides robust and secure API for QoS specification. This API enables applications to programmatically (HTTP-JSON) specify required QoS by associating 5G QoS Identifiers (5QIs) to flow identifers, as shown in the figure next.
+
   ![ROS2 Application 5GS Network Programmability](./ros2-app-5gs-network-programmability.png)
-  
+
   Twenty-six standard 5QIs are identified in the latest release-16 by 3GPP [4:Table 5.7.4-1]. We exemplify a few of them in the table below. The variation in service characteristics of the example 5QIs emphasizes the importance of careful 5QI selection.
 
   The 5G network also has the ability to sensibly infer 5QI QoS from DS-based QoS markings in flows.
@@ -123,7 +129,7 @@ enum unique_network_flow_endpoints_requirement_t
 }
 ```
 
-Upon receiving the publisher/subscription creation request, the RMW implementation assigns unique NFEs according to the `require_unique_network_flow_endpoints` option value.  
+Upon receiving the publisher/subscription creation request, the RMW implementation assigns unique NFEs according to the `require_unique_network_flow_endpoints` option value.
 
 The default value of the option is `UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED` which indicates to the RMW implementation that unique NFEs are not required.
 

--- a/articles/zero_copy.md
+++ b/articles/zero_copy.md
@@ -4,6 +4,8 @@ title: Zero Copy via Loaned Messages
 permalink: articles/zero_copy.html
 abstract:
 author: '[Karsten Knese](https://github.com/karsten1987) [William Woodall](https://github.com/wjwwood) [Michael Carroll](https://github.com/mjcarroll)'
+date_written: 2020-02
+last_modified: 2020-04
 published: true
 ---
 
@@ -14,6 +16,12 @@ published: true
 <div class="abstract" markdown="1">
 {{ page.abstract }}
 </div>
+
+Authors: {{ page.author }}
+
+Date Written: {{ page.date_written }}
+
+Last Modified: {% if page.last_modified %}{{ page.last_modified }}{% else %}{{ page.date_written }}{% endif %}
 
 ## Overview
 


### PR DESCRIPTION
Closes #320

The goal is to include a "date written" and possibly a "last modified" YYYY-MM date to each article. The latter is optional and only intended for somewhat significant changes, not typo fixes. I could remove it if it's not deemed to be that important.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>