### PR TITLE
Updated parameter for ``let`` action in design docs

### DIFF
--- a/articles/specs/launch.0.1.1.xsd
+++ b/articles/specs/launch.0.1.1.xsd
@@ -94,7 +94,7 @@
     </xs:annotation>
 
     <xs:complexType>
-      <xs:attribute name="var" type="xs:string" use="required">
+      <xs:attribute name="name" type="xs:string" use="required">
         <xs:annotation>
           <xs:documentation xml:lang="en">
             Name of the launch configuration variable.


### PR DESCRIPTION
This is a follow up to https://github.com/ros2/ros2_documentation/issues/2322, where the design docs should have the parameter has ``name`` instead of ``var`` for the ``let`` action.

Closes https://github.com/ros2/ros2_documentation/issues/2322