### PR TITLE
Use title instead of name in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: ROS 2 Design
+title: ROS 2 Design
 description: "Distilled design documents related to the ROS 2 effort"
 
 url: http://design.ros2.org


### PR DESCRIPTION
`title:` seems to be preferred over `name:` now.

My goal is to try to change the title that Google uses:

![image](https://github.com/ros2/design/assets/3717345/3d85db00-7e13-4edb-90fd-3131ed1a7fa9)

It's not really clear how Google chooses the title of a link, though: https://developers.google.com/search/docs/appearance/title-link